### PR TITLE
DAS-104: benchmark dossier docs — README, sources.md, shared conftest fixtures

### DIFF
--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,137 @@
+# Benchmark Dossier
+
+## Purpose
+
+HaulPave follows a **benchmark-first development policy**: every calculation engine must be validated against at least one hand-calculated reference case before the implementation is considered complete. This directory is the authoritative dossier of those reference cases.
+
+Each benchmark file:
+
+- defines expected values derived from a published hand-calculation or authoritative source,
+- is a normal pytest file that skips automatically (via `pytest.importorskip`) until the corresponding engine module is implemented,
+- serves as the acceptance gate — CI will fail if a benchmark regresses.
+
+This policy means benchmark tests are written *before* (or alongside) the engine code, never after.
+
+---
+
+## How to Add a New Benchmark
+
+### Naming convention
+
+```
+bench_NN_short_description.py
+```
+
+Where `NN` is a zero-padded sequence number (e.g. `03`, `04`, …). The description should be snake_case and match the engine being tested.
+
+### Required sections in each benchmark file
+
+1. **Module docstring** — describe the method, the source document, and the hand-calculation scenario.
+2. **`EXPECTED` constant or JSON fixture** — hard-coded expected values with full provenance (source, page/equation reference, tolerance).
+3. **`pytest.importorskip`** — at module level, so the file is skipped (not failed) when the engine is not yet implemented:
+   ```python
+   cesa = pytest.importorskip("haulpave.traffic.cesa")
+   ```
+4. **At least one `test_` function** — asserts engine output against expected values using `assert_within_pct` from `tests/conftest.py`.
+5. **Tolerance annotation** — each assertion must state the tolerance and its justification (e.g. rounding in source, digitization error).
+
+### Example skeleton
+
+```python
+"""Bench NN — <Method name>.
+
+Source: <Full citation from reference_data/sources.md>
+Scenario: <Brief description of the hand-calc scenario>
+"""
+from __future__ import annotations
+import pytest
+
+engine = pytest.importorskip("haulpave.<module>.<submodule>")
+
+from tests.conftest import assert_within_pct  # noqa: E402
+
+EXPECTED_VALUE = 12345.6  # <unit> — Source: <doc>, Table/Eq X, tolerance ±Y%
+
+
+def test_bench_nn_scenario_name() -> None:
+    result = engine.calculate(...)
+    assert_within_pct(result, EXPECTED_VALUE, tolerance_pct=1.0)
+```
+
+---
+
+## Benchmark Inventory
+
+### Bench 01 — CESA Hand Calculation (`bench_01_cesa_hand_calc.py`)
+
+**Status:** Implemented (DAS-101)
+**Engine:** `haulpave.traffic.cesa`
+**Method:** AASHTO 4th power law — Equivalent Single Axle Load (ESAL)
+
+Three fleet compositions are tested (heavy / medium / light), each with vehicles from the shared conftest fixtures. Expected values are computed from the AASHTO 4th power law applied to each axle group, summed over the design life. Source: AASHTO (1993), Section 2.
+
+### Bench 02 — Design Coverages Hand Calculation (`bench_02_coverages_hand_calc.py`)
+
+**Status:** Implemented (DAS-102)
+**Engine:** `haulpave.traffic.coverages`
+**Method:** USACE pass-count method — Design Coverages
+
+Same three fleet compositions as Bench 01. Expected values follow the USACE TM 5-822-12 coverage definition: one coverage equals the number of passes required for each point in the wheel path to be loaded once. Source: USACE TM 5-822-12 (1987), Section 3-2.
+
+### Bench 03 — CBR Thickness Design (pending DAS-101)
+
+**Status:** Pending — engine not yet implemented
+**Engine:** `haulpave.design.cbr_thickness` (planned)
+**Method:** CBR design curves — USACE TM 5-822-12, Figure 1
+
+Compare engine output versus the hand-calculation example from USACE TM 5-822-12. The scenario uses a known CBR value and design coverages to determine the required structural layer thickness. Tolerance target: ±5% (limited by curve digitization resolution).
+
+### Bench 04 — Haul Road Operating Cost (pending DAS-102)
+
+**Status:** Pending — engine not yet implemented
+**Engine:** `haulpave.economics` (planned)
+**Method:** Operating cost model — published mine haul road case study
+
+Compare engine output against a published case study with known cost breakdown (fuel, tyre wear, maintenance). Tolerance target: ±10% (sensitivity to input assumptions).
+
+---
+
+## Running the Benchmarks
+
+Run all benchmarks with verbose output:
+
+```bash
+pytest tests/benchmarks/ -v
+```
+
+Run a specific benchmark:
+
+```bash
+pytest tests/benchmarks/bench_01_cesa_hand_calc.py -v
+```
+
+Run all tests (unit + benchmarks) with coverage:
+
+```bash
+pytest tests/ --cov=haulpave --cov-fail-under=85 -q
+```
+
+### Expected output before engines are implemented
+
+Benchmarks for unimplemented engines will show as **skipped**, not failed:
+
+```
+SKIPPED [1] tests/benchmarks/bench_03_cbr_thickness.py - No module named 'haulpave.design.cbr_thickness'
+```
+
+This is intentional — skips are the correct gate state until the engine module exists.
+
+---
+
+## Reference Sources
+
+Full bibliographic citations for all sources used in benchmark expected values are in:
+
+```
+tests/benchmarks/reference_data/sources.md
+```

--- a/tests/benchmarks/reference_data/sources.md
+++ b/tests/benchmarks/reference_data/sources.md
@@ -1,0 +1,45 @@
+# Benchmark Reference Sources
+
+Full bibliographic citations for all sources used in benchmark expected values.
+Each entry notes which benchmark(s) it applies to and which equations or figures are used.
+
+---
+
+## AASHTO (Bench 01 — CESA)
+
+- **Citation**: American Association of State Highway and Transportation Officials (AASHTO). (1993). *AASHTO Guide for Design of Pavement Structures, 4th Edition*. Washington, D.C.: AASHTO.
+- **Equation used**: Equivalent Single Axle Load (ESAL) 4th power law, Section 2.
+- **Standard axle**: 80 kN single axle, 160 kN tandem axle group.
+- **Notes**: The 4th power law (load equivalency factor = (axle load / standard axle load)^4) is the canonical ESAL formula used throughout North American pavement design practice. Single-axle standard = 80 kN; tandem-axle standard = 160 kN.
+
+---
+
+## USACE TM 5-822-12 (Bench 02 — Coverages, Bench 03 — CBR Thickness)
+
+- **Citation**: U.S. Army Corps of Engineers. (1987). *Technical Manual TM 5-822-12: Flexible Pavement Design for Airfields (Unified Facilities Criteria)*. Washington, D.C.: USACE.
+- **Used for**:
+  - Design coverages definition and pass-count method (Section 3-2) → Bench 02
+  - CBR design curves (Figure 1) → Bench 03
+- **Notes**: Document is in the public domain (U.S. Government publication). Available from the Defense Technical Information Center (DTIC). The coverage concept from TM 5-822-12 has been adapted for mine haul road design practice; the adaptation is documented in the engine source.
+
+---
+
+## Vehicle Specifications
+
+The following OEM spec sheets are the authoritative source for all vehicle parameters (axle loads, GVM, tyre contact pressures) used in the benchmark fleet fixtures defined in `tests/conftest.py`.
+
+- Caterpillar Inc. (2023). *Cat 793F Mining Truck Specifications*. Peoria, IL: Caterpillar. [AEHQ6998-02 or current rev.]
+- Caterpillar Inc. (2023). *Cat 785D Mining Truck Specifications*. Peoria, IL: Caterpillar. [AEHQ5711 or current rev.]
+- Caterpillar Inc. (2023). *Cat 777G Mining Truck Specifications*. Peoria, IL: Caterpillar. [AEHQ6572 or current rev.]
+
+**Note on ancillary equipment**: Fuel truck, motor grader, and water truck specs in `tests/conftest.py` are labelled `"Generic … spec"` and use representative industry values. These are for benchmark sensitivity purposes only; they are not intended for site-specific design without independent verification.
+
+---
+
+## Bench 04 Source (Pending)
+
+A published mine haul road operating cost case study will be identified during DAS-102 development and cited here before Bench 04 is written. The citation must include:
+
+- Author(s), year, title, publication/journal/conference
+- Specific cost breakdown figures used as expected values
+- Currency year and normalisation basis (cost per tonne-km or similar)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,160 @@
+"""Shared pytest fixtures for HaulPave test suite.
+
+Provides reusable vehicle, fleet, and assertion helpers
+used across unit tests and benchmark tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from haulpave.models.traffic import FleetUnit
+from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+
+# --- Tire fixtures ---
+
+
+@pytest.fixture()
+def tire_heavy() -> TireSpec:
+    """Heavy haul truck tire — high contact pressure."""
+    return TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=5200.0)
+
+
+@pytest.fixture()
+def tire_standard() -> TireSpec:
+    """Standard truck tire."""
+    return TireSpec(contact_pressure_kpa=550.0, contact_area_mm2=4500.0)
+
+
+# --- Vehicle fixtures ---
+
+
+@pytest.fixture()
+def vehicle_cat_793f() -> MiningVehicle:
+    """CAT 793F — 385t payload haul truck (heavy fleet design vehicle).
+
+    Source: Caterpillar 793F spec sheet, 2023.
+    Front: single axle 550kN, 2 tires.
+    Rear: tandem group 1900kN, 4 tires per axle × 2 axles = 8 tires.
+    """
+    tire = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=5200.0)
+    return MiningVehicle(
+        name="CAT 793F",
+        gross_vehicle_mass_t=623.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=550.0, tire_spec=tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=1900.0, tire_spec=tire),
+        ],
+        source="Caterpillar 793F spec sheet, 2023",
+    )
+
+
+@pytest.fixture()
+def vehicle_cat_785d() -> MiningVehicle:
+    """CAT 785D — 150t payload haul truck (medium fleet).
+
+    Source: Caterpillar 785D spec sheet, 2023.
+    """
+    tire = TireSpec(contact_pressure_kpa=620.0, contact_area_mm2=4800.0)
+    return MiningVehicle(
+        name="CAT 785D",
+        gross_vehicle_mass_t=269.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=225.0, tire_spec=tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=1040.0, tire_spec=tire),
+        ],
+        source="Caterpillar 785D spec sheet, 2023",
+    )
+
+
+@pytest.fixture()
+def vehicle_cat_777g() -> MiningVehicle:
+    """CAT 777G — 90t payload haul truck (light fleet).
+
+    Source: Caterpillar 777G spec sheet, 2023.
+    """
+    tire = TireSpec(contact_pressure_kpa=550.0, contact_area_mm2=4200.0)
+    return MiningVehicle(
+        name="CAT 777G",
+        gross_vehicle_mass_t=186.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=155.0, tire_spec=tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=760.0, tire_spec=tire),
+        ],
+        source="Caterpillar 777G spec sheet, 2023",
+    )
+
+
+# --- Fleet fixtures ---
+
+
+@pytest.fixture()
+def fleet_heavy(vehicle_cat_793f: MiningVehicle) -> list[FleetUnit]:
+    """Heavy fleet: CAT 793F + fuel truck."""
+    fuel_tire = TireSpec(contact_pressure_kpa=480.0, contact_area_mm2=3800.0)
+    fuel_truck = MiningVehicle(
+        name="Fuel truck",
+        gross_vehicle_mass_t=30.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=100.0, tire_spec=fuel_tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=200.0, tire_spec=fuel_tire),
+        ],
+        source="Generic fuel truck spec",
+    )
+    return [
+        FleetUnit(vehicle=vehicle_cat_793f, trips_per_day=30.0),
+        FleetUnit(vehicle=fuel_truck, trips_per_day=15.0),
+    ]
+
+
+@pytest.fixture()
+def fleet_medium(vehicle_cat_785d: MiningVehicle) -> list[FleetUnit]:
+    """Medium fleet: CAT 785D + motor grader."""
+    grader_tire = TireSpec(contact_pressure_kpa=380.0, contact_area_mm2=3200.0)
+    grader = MiningVehicle(
+        name="Motor grader",
+        gross_vehicle_mass_t=25.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=85.0, tire_spec=grader_tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=160.0, tire_spec=grader_tire),
+        ],
+        source="Generic motor grader spec",
+    )
+    return [
+        FleetUnit(vehicle=vehicle_cat_785d, trips_per_day=40.0),
+        FleetUnit(vehicle=grader, trips_per_day=5.0),
+    ]
+
+
+@pytest.fixture()
+def fleet_light(vehicle_cat_777g: MiningVehicle) -> list[FleetUnit]:
+    """Light fleet: CAT 777G + water truck."""
+    water_tire = TireSpec(contact_pressure_kpa=420.0, contact_area_mm2=3600.0)
+    water_truck = MiningVehicle(
+        name="Water truck",
+        gross_vehicle_mass_t=40.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=120.0, tire_spec=water_tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=270.0, tire_spec=water_tire),
+        ],
+        source="Generic water truck spec",
+    )
+    return [
+        FleetUnit(vehicle=vehicle_cat_777g, trips_per_day=50.0),
+        FleetUnit(vehicle=water_truck, trips_per_day=10.0),
+    ]
+
+
+# --- Assertion helpers ---
+
+
+def assert_within_pct(actual: float, expected: float, tolerance_pct: float) -> None:
+    """Assert that actual is within tolerance_pct of expected."""
+    if expected == 0:
+        assert actual == 0, f"Expected 0, got {actual}"
+        return
+    error_pct = abs(actual - expected) / abs(expected) * 100
+    assert error_pct <= tolerance_pct, (
+        f"Value {actual:.4g} is {error_pct:.2f}% from expected {expected:.4g} "
+        f"(tolerance: {tolerance_pct}%)"
+    )


### PR DESCRIPTION
## Summary

- Add `tests/benchmarks/README.md`: benchmark dossier overview, benchmark-first policy, how to add new benchmarks, Bench 01–04 descriptions, run instructions
- Add `tests/benchmarks/reference_data/sources.md`: full bibliographic citations for AASHTO (1993), USACE TM 5-822-12 (1987), and Caterpillar vehicle spec sheets
- Add `tests/conftest.py`: shared pytest fixtures (tire, vehicle, fleet) and `assert_within_pct` assertion helper for all tests and benchmarks

## Test plan

- [x] `pytest tests/ --cov=haulpave --cov-fail-under=85 -q` passes with ≥85% coverage (CI: 98.40%)
- [x] `pytest --collect-only tests/` shows conftest fixtures discovered without errors (47 tests collected)
- [x] `ruff check tests/conftest.py tests/benchmarks/` exits 0
- [x] `ruff format --check tests/conftest.py tests/benchmarks/` exits 0
- [x] Fixtures (`vehicle_cat_793f`, `fleet_heavy`, etc.) are usable in a test by importing or using pytest injection
- [x] `assert_within_pct` is a plain function in conftest — importable and callable