### PR TITLE
DAS-109: v0.1.0 release — bump version, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ HaulPave uses [Semantic Versioning](https://semver.org/).
 - Phase 1: Pavement design engine — `haulpave.pavement.design_pavement` CBR thickness (DAS-108)
 
 ### Technical
-- All 4 benchmark test files pass with no skips
-- 144 unit tests, 98.5% coverage
+- All 4 benchmark test files pass with no skips (as of 2026-03-25)
+- 144 unit tests, 98.5% coverage (as of 2026-03-25)
 - Python 3.10+ compatible, tested on 3.10, 3.11, 3.12
 - SI units throughout (mm, kN, tonnes)
 - Confidence labels: all engines are `benchmark_tested`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,28 @@
 # Changelog
 
-All notable changes to HaulPave are documented here.
+All notable changes to this project will be documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 HaulPave uses [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [0.1.0] — 2026-03-25
 
 ### Added
-- Project scaffold: `pyproject.toml`, package structure, pre-commit hooks (DAS-97)
+- Phase 0: Project scaffolding — pyproject.toml, package structure, pre-commit hooks (DAS-97)
+- Phase 0: Pydantic data models — Vehicle, Traffic, Material, Pavement, Economics (DAS-98)
+- Phase 0: Benchmark 01 — CESA hand-calc, 3 fleet compositions (DAS-99)
+- Phase 0: Benchmark 02 — Coverages hand-calc, USACE pass counts (DAS-100)
+- Phase 0: Digitize USACE CBR design curves + interpolation utility (DAS-103)
+- Phase 0: Benchmark dossier documentation — README, sources.md, conftest.py (DAS-104)
+- Phase 1: CESA engine — `haulpave.traffic.cesa.compute_cesa` AASHTO 4th-power LEF (DAS-106)
+- Phase 1: Coverages engine — `haulpave.traffic.coverages.compute_coverages` USACE TM 5-822-12 (DAS-107)
+- Phase 1: Pavement design engine — `haulpave.pavement.design_pavement` CBR thickness (DAS-108)
 
----
-
-*First release planned: v0.1.0 (Phase 1 completion)*
+### Technical
+- All 4 benchmark test files pass with no skips
+- 144 unit tests, 98.5% coverage
+- Python 3.10+ compatible, tested on 3.10, 3.11, 3.12
+- SI units throughout (mm, kN, tonnes)
+- Confidence labels: all engines are `benchmark_tested`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haulpave"
-version = "0.0.1"
+version = "0.1.0"
 description = "Open-source pavement structure and operating-cost analysis toolkit for mine haul roads"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/haulpave/__init__.py
+++ b/src/haulpave/__init__.py
@@ -8,4 +8,4 @@ roads and estimating operating-cost impacts.
 Docs: https://github.com/rachmad-jenss/haul-pave
 """
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.0 in pyproject.toml and src/haulpave/__init__.py
- Adds CHANGELOG.md with complete Phase 0 + Phase 1 history
- All 4 benchmark tests verified PASS on this branch

## Test plan
- [x] `pytest tests/benchmarks/ -v` — all 32 benchmark tests PASS
- [x] `python -c "import haulpave; print(haulpave.__version__)"` shows 0.1.0
- [x] `ruff check src tests` passes
- [x] `mypy src` passes