### PR TITLE
DAS-113: comparison engine — USACE TM 5-822-12 vs TRH 14 (CSRA 1985)

### DIFF
--- a/src/haulpave/pavement/__init__.py
+++ b/src/haulpave/pavement/__init__.py
@@ -26,7 +26,7 @@ from haulpave.traffic.cesa import compute_cesa
 from haulpave.traffic.coverages import compute_coverages
 from haulpave.utils.interpolation import interpolate_thickness, load_curve_data
 
-__all__ = ["PavementResult", "design_pavement"]
+__all__ = ["ComparisonResult", "PavementResult", "compare_methods", "design_pavement"]
 
 
 @dataclass(frozen=True)
@@ -110,3 +110,8 @@ def design_pavement(
         required_thickness_mm=thickness,
         design_wheel_load_kn=cov_result.design_wheel_load_kn,
     )
+
+
+# Bottom import — avoids circular dependency: compare.py imports PavementResult
+# and design_pavement from this module (already defined above by this point).
+from haulpave.pavement.compare import ComparisonResult, compare_methods  # noqa: E402

--- a/src/haulpave/pavement/compare.py
+++ b/src/haulpave/pavement/compare.py
@@ -1,0 +1,116 @@
+"""Comparison engine — USACE TM 5-822-12 CBR vs TRH 14 (CSRA 1985).
+
+Runs both pavement design engines on the same traffic input and subgrade CBR,
+returning a side-by-side ComparisonResult with the thickness delta.
+
+Pipeline
+--------
+1. USACE CBR path (``design_pavement``) — CESA + coverages + USACE CBR curves.
+2. TRH 14 path (``compute_trh14``) — USACE coverages + TRH 14 catalog.
+3. delta_mm = TRH 14 thickness − USACE thickness.
+
+Confidence label: ``benchmark_tested`` — both sub-engines are benchmark_tested;
+comparison arithmetic is verified in tests against known sub-results.
+
+References
+----------
+- USACE TM 5-822-12 (1990). Flexible Pavement Design for Airfields.
+- CSRA (1985). Technical Recommendations for Highways 14 (TRH 14).
+- Thompson, R.J. and Visser, A.T. (2006). "The Functional Design of Surface
+  Mine Haul Roads." Journal of the South African Institute of Mining and
+  Metallurgy, vol. 106, pp. 29–36.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from haulpave.models.traffic import TrafficInput
+from haulpave.pavement import PavementResult, design_pavement
+from haulpave.pavement.trh14 import TRH14Result, compute_trh14
+
+__all__ = ["ComparisonResult", "compare_methods"]
+
+_DEFAULT_CURVE_ID = "usace_cbr_v1"
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    """Side-by-side result of USACE CBR vs TRH 14 pavement design.
+
+    Attributes
+    ----------
+    usace:
+        Full result from the USACE TM 5-822-12 CBR design path.
+    trh14:
+        Full result from the TRH 14 (CSRA 1985) design catalog path.
+    delta_mm:
+        Thickness difference: ``trh14.total_thickness_mm −
+        usace.required_thickness_mm`` [mm].  Positive → TRH 14 requires
+        more material; negative → TRH 14 is more conservative (thinner).
+    subgrade_cbr:
+        Subgrade CBR [%] used for both calculations.
+    curve_id:
+        USACE CBR curve dataset identifier used.
+    method:
+        Human-readable method identifier.
+    confidence:
+        Confidence label.  Inherits from sub-engines: both are
+        ``benchmark_tested``.
+    """
+
+    usace: PavementResult
+    trh14: TRH14Result
+    delta_mm: float
+    subgrade_cbr: float
+    curve_id: str
+    method: str = "USACE TM 5-822-12 CBR vs TRH 14 (CSRA 1985) comparison"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
+        "benchmark_tested"
+    )
+
+
+def compare_methods(
+    traffic: TrafficInput,
+    subgrade_cbr: float,
+    curve_id: str = _DEFAULT_CURVE_ID,
+) -> ComparisonResult:
+    """Compare USACE TM 5-822-12 CBR and TRH 14 pavement design results.
+
+    Runs both engines on identical inputs and returns the combined result
+    including the thickness delta.
+
+    Parameters
+    ----------
+    traffic:
+        ``TrafficInput`` containing fleet mix, design life, and working days.
+    subgrade_cbr:
+        Subgrade CBR value [%].  Must satisfy both engines' constraints:
+        within the USACE curve range **and** ≥ 2% (TRH 14 G7 minimum).
+    curve_id:
+        USACE CBR curve dataset identifier, e.g. ``"usace_cbr_v1"``.
+        Defaults to ``"usace_cbr_v1"``.
+
+    Returns
+    -------
+    ComparisonResult
+        Frozen dataclass containing both sub-results and the thickness delta.
+
+    Raises
+    ------
+    ValueError
+        Propagated from either sub-engine — e.g. CBR out of USACE curve
+        range, or G8/G9 subgrade (CBR < 2%) not in TRH 14 catalog.
+    """
+    usace_result = design_pavement(traffic, subgrade_cbr, curve_id)
+    trh14_result = compute_trh14(traffic, subgrade_cbr)
+    delta = trh14_result.total_thickness_mm - usace_result.required_thickness_mm
+
+    return ComparisonResult(
+        usace=usace_result,
+        trh14=trh14_result,
+        delta_mm=delta,
+        subgrade_cbr=subgrade_cbr,
+        curve_id=curve_id,
+    )

--- a/src/haulpave/pavement/compare.py
+++ b/src/haulpave/pavement/compare.py
@@ -48,7 +48,7 @@ class ComparisonResult:
     delta_mm:
         Thickness difference: ``trh14.total_thickness_mm −
         usace.required_thickness_mm`` [mm].  Positive → TRH 14 requires
-        more material; negative → TRH 14 is more conservative (thinner).
+        more material than USACE; negative → USACE requires more material.
     subgrade_cbr:
         Subgrade CBR [%] used for both calculations.
     curve_id:

--- a/tests/test_pavement/test_compare.py
+++ b/tests/test_pavement/test_compare.py
@@ -1,0 +1,208 @@
+"""Unit tests for haulpave.pavement.compare.
+
+Tests cover:
+  - compare_methods: return type, field values, delta arithmetic
+  - ComparisonResult: both sub-results are correct types
+  - Fleet D × 3 CBR values (G4/G5/G6) — same fleet as bench_05
+  - Error propagation from sub-engines
+  - Default curve_id behaviour
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from haulpave.models.traffic import FleetUnit, TrafficInput
+from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.pavement import PavementResult, compare_methods
+from haulpave.pavement.compare import ComparisonResult
+from haulpave.pavement.trh14 import TRH14Result
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+_PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
+
+
+def _single(load_kn: float) -> AxleGroup:
+    return AxleGroup(
+        axle_count=1,
+        tyres_per_axle=2,
+        gross_load_kn=load_kn,
+        tire_spec=_PLACEHOLDER_TIRE,
+    )
+
+
+def _tandem(load_kn: float) -> AxleGroup:
+    return AxleGroup(
+        axle_count=2,
+        tyres_per_axle=4,
+        gross_load_kn=load_kn,
+        tire_spec=_PLACEHOLDER_TIRE,
+    )
+
+
+@pytest.fixture()
+def fleet_d() -> TrafficInput:
+    """Fleet D — bench_05 fixture: Generic 100t haul truck, 25 trips/day.
+
+    design_wheel_load = 65.0 kN (front axle governs)
+    total_coverages   = 75.0 × 300 × 3 = 67,500
+    """
+    truck = MiningVehicle(
+        name="Generic 100t Haul Truck",
+        gross_vehicle_mass_t=100.0,
+        axle_groups=[_single(130.0), _tandem(520.0)],
+        source="bench_05 design fixture",
+    )
+    return TrafficInput(
+        fleet=[FleetUnit(vehicle=truck, trips_per_day=25)],
+        design_life_years=3,
+        working_days_per_year=300,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Return type and structure
+# ---------------------------------------------------------------------------
+class TestCompareMethodsReturnType:
+    def test_returns_comparison_result(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert isinstance(result, ComparisonResult)
+
+    def test_usace_field_is_pavement_result(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert isinstance(result.usace, PavementResult)
+
+    def test_trh14_field_is_trh14_result(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert isinstance(result.trh14, TRH14Result)
+
+    def test_fields_present(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert result.subgrade_cbr == pytest.approx(12.0)
+        assert result.curve_id == "usace_cbr_v1"
+        assert "USACE" in result.method
+        assert "TRH 14" in result.method
+        assert result.confidence == "benchmark_tested"
+
+
+# ---------------------------------------------------------------------------
+# Delta arithmetic — core invariant
+# ---------------------------------------------------------------------------
+class TestDeltaArithmetic:
+    @pytest.mark.parametrize("cbr", [5.0, 12.0, 20.0])
+    def test_delta_equals_trh14_minus_usace(self, fleet_d: TrafficInput, cbr: float) -> None:
+        """delta_mm must exactly equal trh14 thickness − usace thickness."""
+        result = compare_methods(fleet_d, subgrade_cbr=cbr)
+        expected_delta = result.trh14.total_thickness_mm - result.usace.required_thickness_mm
+        assert result.delta_mm == pytest.approx(expected_delta, abs=1e-9)
+
+    def test_delta_sign_g6(self, fleet_d: TrafficInput) -> None:
+        """For soft subgrade (G6, CBR=5%), TRH 14 is typically thicker than USACE."""
+        result = compare_methods(fleet_d, subgrade_cbr=5.0)
+        # Both methods should produce positive thickness; delta can go either way
+        assert result.usace.required_thickness_mm > 0
+        assert result.trh14.total_thickness_mm > 0
+
+    def test_delta_is_float(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert isinstance(result.delta_mm, float)
+
+
+# ---------------------------------------------------------------------------
+# Sub-engine consistency — coverages and wheel load must match
+# ---------------------------------------------------------------------------
+class TestSubEngineConsistency:
+    def test_coverages_match(self, fleet_d: TrafficInput) -> None:
+        """Both sub-engines use the same coverages engine — values must agree."""
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert result.usace.total_coverages == pytest.approx(result.trh14.total_coverages, rel=1e-6)
+
+    def test_design_wheel_load_match(self, fleet_d: TrafficInput) -> None:
+        """Both sub-engines must use the same design wheel load."""
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert result.usace.design_wheel_load_kn == pytest.approx(
+            result.trh14.design_wheel_load_kn, rel=1e-6
+        )
+
+    def test_g_class_matches_subgrade_cbr(self, fleet_d: TrafficInput) -> None:
+        """TRH 14 G-class must be consistent with the input CBR."""
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert result.trh14.material_class == "G5"
+
+        result_g6 = compare_methods(fleet_d, subgrade_cbr=5.0)
+        assert result_g6.trh14.material_class == "G6"
+
+        result_g4 = compare_methods(fleet_d, subgrade_cbr=20.0)
+        assert result_g4.trh14.material_class == "G4"
+
+
+# ---------------------------------------------------------------------------
+# Fleet D × 3 CBR values — thickness sanity checks
+# ---------------------------------------------------------------------------
+class TestFleetDThicknesses:
+    """Both methods should produce physically plausible results for Fleet D.
+
+    Acceptance range (loose): 100–900 mm for mine haul road design.
+    """
+
+    _MIN_MM = 100.0
+    _MAX_MM = 900.0
+
+    @pytest.mark.parametrize("cbr", [5.0, 12.0, 20.0])
+    def test_usace_thickness_in_range(self, fleet_d: TrafficInput, cbr: float) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=cbr)
+        assert self._MIN_MM <= result.usace.required_thickness_mm <= self._MAX_MM
+
+    @pytest.mark.parametrize("cbr", [5.0, 12.0, 20.0])
+    def test_trh14_thickness_in_range(self, fleet_d: TrafficInput, cbr: float) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=cbr)
+        assert self._MIN_MM <= result.trh14.total_thickness_mm <= self._MAX_MM
+
+    def test_thickness_decreases_with_cbr_usace(self, fleet_d: TrafficInput) -> None:
+        """Stronger subgrade → thinner USACE design."""
+        t_g6 = compare_methods(fleet_d, subgrade_cbr=5.0).usace.required_thickness_mm
+        t_g5 = compare_methods(fleet_d, subgrade_cbr=12.0).usace.required_thickness_mm
+        t_g4 = compare_methods(fleet_d, subgrade_cbr=20.0).usace.required_thickness_mm
+        assert t_g6 > t_g5 > t_g4
+
+    def test_thickness_decreases_with_cbr_trh14(self, fleet_d: TrafficInput) -> None:
+        """Stronger subgrade → thinner TRH 14 design."""
+        t_g6 = compare_methods(fleet_d, subgrade_cbr=5.0).trh14.total_thickness_mm
+        t_g5 = compare_methods(fleet_d, subgrade_cbr=12.0).trh14.total_thickness_mm
+        t_g4 = compare_methods(fleet_d, subgrade_cbr=20.0).trh14.total_thickness_mm
+        assert t_g6 > t_g5 > t_g4
+
+
+# ---------------------------------------------------------------------------
+# Default curve_id
+# ---------------------------------------------------------------------------
+class TestDefaultCurveId:
+    def test_default_curve_id_is_usace_cbr_v1(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0)
+        assert result.curve_id == "usace_cbr_v1"
+
+    def test_explicit_curve_id_stored(self, fleet_d: TrafficInput) -> None:
+        result = compare_methods(fleet_d, subgrade_cbr=12.0, curve_id="usace_cbr_v1")
+        assert result.curve_id == "usace_cbr_v1"
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+class TestErrorPropagation:
+    def test_g8_subgrade_raises(self, fleet_d: TrafficInput) -> None:
+        """G8/G9 CBR (1.7%) raises ValueError — USACE curve minimum is 2.0%,
+        so USACE raises before TRH 14 gets a chance to raise its own error."""
+        with pytest.raises(ValueError, match="CBR"):
+            compare_methods(fleet_d, subgrade_cbr=1.7)
+
+    def test_g9_subgrade_raises(self, fleet_d: TrafficInput) -> None:
+        """Very low CBR (0.5%) raises ValueError from USACE (below curve range)."""
+        with pytest.raises(ValueError, match="CBR"):
+            compare_methods(fleet_d, subgrade_cbr=0.5)
+
+    def test_negative_cbr_raises(self, fleet_d: TrafficInput) -> None:
+        with pytest.raises(ValueError, match="CBR"):
+            compare_methods(fleet_d, subgrade_cbr=-1.0)

--- a/tests/test_pavement/test_compare.py
+++ b/tests/test_pavement/test_compare.py
@@ -98,10 +98,9 @@ class TestDeltaArithmetic:
         expected_delta = result.trh14.total_thickness_mm - result.usace.required_thickness_mm
         assert result.delta_mm == pytest.approx(expected_delta, abs=1e-9)
 
-    def test_delta_sign_g6(self, fleet_d: TrafficInput) -> None:
-        """For soft subgrade (G6, CBR=5%), TRH 14 is typically thicker than USACE."""
+    def test_both_thicknesses_positive_g6(self, fleet_d: TrafficInput) -> None:
+        """Both sub-engines must produce positive thickness for G6 (CBR=5%)."""
         result = compare_methods(fleet_d, subgrade_cbr=5.0)
-        # Both methods should produce positive thickness; delta can go either way
         assert result.usace.required_thickness_mm > 0
         assert result.trh14.total_thickness_mm > 0
 


### PR DESCRIPTION
## Summary

- Add \`haulpave/pavement/compare.py\`: \`compare_methods(traffic, subgrade_cbr, curve_id)\` + frozen \`ComparisonResult\` dataclass — runs both USACE and TRH 14 engines on identical inputs and exposes \`delta_mm\` (TRH 14 thickness − USACE thickness)
- Update \`pavement/__init__.py\`: export \`ComparisonResult\` and \`compare_methods\` via bottom import (avoids circular dependency since \`compare.py\` imports from this module)
- Add 25 unit tests in \`tests/test_pavement/test_compare.py\` covering return type, delta arithmetic invariant, sub-engine consistency (coverages + wheel load must match), Fleet D × 3 CBR values (G4/G5/G6), error propagation, and default \`curve_id\`

Confidence: \`benchmark_tested\` — inherits from both sub-engines (USACE via bench_03/04; TRH 14 via bench_05)

## Test plan

- [x] \`pytest tests/ -q\` — all 206 tests pass
- [x] \`pytest tests/test_pavement/test_compare.py -v\` — all 25 unit tests pass
- [x] Coverage ≥ 85% (\`pytest --cov=src/haulpave --cov-fail-under=85\`) — 97.97%
- [x] \`ruff check src/ tests/\` — no lint errors
- [x] \`mypy src/ --ignore-missing-imports\` — no type errors
- [x] \`from haulpave.pavement import compare_methods, ComparisonResult\` imports cleanly (no circular import)
- [x] \`compare_methods(fleet_d, cbr=12.0).delta_mm == result.trh14.total_thickness_mm - result.usace.required_thickness_mm\` — verified (-31.8133mm)
- [x] \`compare_methods(fleet_d, cbr=12.0).trh14.material_class == "G5"\`
- [x] \`compare_methods(fleet_d, cbr=1.7)\` raises \`ValueError\` (CBR below USACE curve range)