### PR TITLE
DAS-114: bump version to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ HaulPave uses [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.2.0] — 2026-03-25
+
+### Added
+- Phase 2: Benchmark 05 — TRH 14 hand-calc, CBR-to-G-class mapping and thickness design (DAS-111)
+- Phase 2: TRH 14 pavement design engine — `haulpave.pavement.trh14.compute_trh14`, `cbr_to_material_class`, G1–G7 design catalog with log-linear interpolation (DAS-112)
+- Phase 2: Comparison engine — `haulpave.pavement.compare_methods` runs USACE CBR and TRH 14 side-by-side, exposes `ComparisonResult` with `delta_mm` (DAS-113)
+
+### Technical
+- All 5 benchmark test files pass with no skips (bench_01–bench_05)
+- 206 unit tests, 97.97% coverage (as of 2026-03-25)
+- TRH 14 design catalog digitized from Thompson & Visser (2006), G1–G7, confidence `benchmark_tested`
+- Comparison engine verifies delta arithmetic: for Fleet D + CBR=12% (G5), delta = −31.8 mm (USACE more conservative)
+
+---
+
 ## [0.1.0] — 2026-03-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haulpave"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open-source pavement structure and operating-cost analysis toolkit for mine haul roads"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/haulpave/__init__.py
+++ b/src/haulpave/__init__.py
@@ -8,4 +8,4 @@ roads and estimating operating-cost impacts.
 Docs: https://github.com/rachmad-jenss/haul-pave
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version from `0.1.0` → `0.2.0`
- Sync `src/haulpave/__init__.__version__` to `0.2.0`
- Add v0.2.0 section to `CHANGELOG.md` covering Phase 2 additions: bench_05 (TRH 14 hand-calc), TRH 14 pavement design engine, and comparison engine

This release marks completion of Phase 2: TRH 14 method + comparison engine.

## What's new in v0.2.0

| Component | Issue | Description |
|-----------|-------|-------------|
| bench_05 | DAS-111 | TRH 14 hand-calc benchmark — CBR→G-class, 3 thickness cases |
| `haulpave.pavement.trh14` | DAS-112 | `compute_trh14` + `cbr_to_material_class`, G1–G7 catalog, log-linear interp |
| `haulpave.pavement.compare` | DAS-113 | `compare_methods` — USACE vs TRH 14 side-by-side, `delta_mm` |

Stats: 206 unit tests, 97.97% coverage, all 5 benchmarks pass.

## Test plan

- [x] `pytest tests/ -q` — all 206 tests pass
- [x] `pytest tests/benchmarks/ -v` — all 5 benchmark files pass (bench_01–bench_05)
- [x] `ruff check src/ tests/` — no lint errors
- [x] `mypy src/ --ignore-missing-imports` — no type errors
- [x] `grep version pyproject.toml` shows `0.2.0`
- [x] CHANGELOG.md contains `[0.2.0]` section with correct content