### PR TITLE
[DAS-56] Consolidate duplicated test helpers into conftest.py

### DIFF
--- a/tests/benchmarks/bench_04_published_case.py
+++ b/tests/benchmarks/bench_04_published_case.py
@@ -92,7 +92,7 @@ SUBGRADE_CBR = CASE["subgrade_cbr"]  # 7
 from haulpave.models.traffic import FleetUnit, TrafficInput  # noqa: E402
 from haulpave.models.vehicle import MiningVehicle  # noqa: E402
 
-from ..conftest import make_single_axle, make_tandem_axle
+from ..conftest import make_single_axle, make_tandem_axle  # noqa: E402
 
 
 @pytest.fixture()

--- a/tests/benchmarks/bench_04_published_case.py
+++ b/tests/benchmarks/bench_04_published_case.py
@@ -90,29 +90,9 @@ SUBGRADE_CBR = CASE["subgrade_cbr"]  # 7
 # Fleet B fixtures — identical to bench_01 / bench_02 Fleet B
 # ---------------------------------------------------------------------------
 from haulpave.models.traffic import FleetUnit, TrafficInput  # noqa: E402
-from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec  # noqa: E402
+from haulpave.models.vehicle import MiningVehicle  # noqa: E402
 
-_PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
-
-
-def _single(load_kn: float) -> AxleGroup:
-    """Single axle group: 1 axle, 2 tyres."""
-    return AxleGroup(
-        axle_count=1,
-        tyres_per_axle=2,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
-
-
-def _tandem(load_kn: float) -> AxleGroup:
-    """Tandem axle group: 2 axles, 4 tyres per axle (dual-tyre stations)."""
-    return AxleGroup(
-        axle_count=2,
-        tyres_per_axle=4,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
+from ..conftest import make_single_axle, make_tandem_axle
 
 
 @pytest.fixture()
@@ -142,8 +122,8 @@ def fleet_b_input() -> TrafficInput:
         name="CAT 785D",
         gross_vehicle_mass_t=cat_ref["gross_vehicle_mass_t"],
         axle_groups=[
-            _single(cat_ref["front_axle_load_kN"]),
-            _tandem(cat_ref["rear_tandem_load_kN"]),
+            make_single_axle(cat_ref["front_axle_load_kN"]),
+            make_tandem_axle(cat_ref["rear_tandem_load_kN"]),
         ],
         source="Caterpillar 785D Specifications, CAT Performance Handbook Ed. 47",
     )
@@ -151,8 +131,8 @@ def fleet_b_input() -> TrafficInput:
         name="Motor Grader (25 t)",
         gross_vehicle_mass_t=grader_ref["gross_vehicle_mass_t"],
         axle_groups=[
-            _single(grader_ref["front_axle_load_kN"]),
-            _tandem(grader_ref["rear_tandem_load_kN"]),
+            make_single_axle(grader_ref["front_axle_load_kN"]),
+            make_tandem_axle(grader_ref["rear_tandem_load_kN"]),
         ],
         source="Generic motor grader — conservative estimate based on GVM",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from haulpave.models.traffic import FleetUnit
+from haulpave.models.traffic import FleetUnit, TrafficInput
 from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
 
 # --- Tire fixtures ---
@@ -143,6 +143,69 @@ def fleet_light(vehicle_cat_777g: MiningVehicle) -> list[FleetUnit]:
         FleetUnit(vehicle=vehicle_cat_777g, trips_per_day=50.0),
         FleetUnit(vehicle=water_truck, trips_per_day=10.0),
     ]
+
+
+# --- Shared test helpers (plain functions — not fixtures, because they take parameters) ---
+
+PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
+
+
+def make_single_axle(load_kn: float) -> AxleGroup:
+    """Single axle: 1 axle, 2 tyres per axle."""
+    return AxleGroup(
+        axle_count=1,
+        tyres_per_axle=2,
+        gross_load_kn=load_kn,
+        tire_spec=PLACEHOLDER_TIRE,
+    )
+
+
+def make_tandem_axle(load_kn: float) -> AxleGroup:
+    """Tandem axle group: 2 axles, 4 tyres per axle (dual-tyre stations)."""
+    return AxleGroup(
+        axle_count=2,
+        tyres_per_axle=4,
+        gross_load_kn=load_kn,
+        tire_spec=PLACEHOLDER_TIRE,
+    )
+
+
+def make_tridem_axle(load_kn: float) -> AxleGroup:
+    """Tridem axle group: 3 axles, 4 tyres per axle."""
+    return AxleGroup(
+        axle_count=3,
+        tyres_per_axle=4,
+        gross_load_kn=load_kn,
+        tire_spec=PLACEHOLDER_TIRE,
+    )
+
+
+def make_vehicle(
+    name: str,
+    axle_groups: list[AxleGroup],
+    gvm_t: float = 50.0,
+) -> MiningVehicle:
+    """Create a MiningVehicle with a synthetic source string."""
+    return MiningVehicle(
+        name=name,
+        gross_vehicle_mass_t=gvm_t,
+        axle_groups=axle_groups,
+        source="Synthetic vehicle for unit tests",
+    )
+
+
+def make_traffic(
+    vehicle: MiningVehicle,
+    trips: float = 10,
+    life_years: float = 10,
+    days_per_year: int = 350,
+) -> TrafficInput:
+    """Create a TrafficInput with a single-vehicle fleet."""
+    return TrafficInput(
+        fleet=[FleetUnit(vehicle=vehicle, trips_per_day=trips)],
+        design_life_years=life_years,
+        working_days_per_year=days_per_year,
+    )
 
 
 # --- Assertion helpers ---

--- a/tests/test_pavement/test_compare.py
+++ b/tests/test_pavement/test_compare.py
@@ -13,33 +13,12 @@ from __future__ import annotations
 import pytest
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
-from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.models.vehicle import MiningVehicle
 from haulpave.pavement import PavementResult, compare_methods
 from haulpave.pavement.compare import ComparisonResult
 from haulpave.pavement.trh14 import TRH14Result
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
-_PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
-
-
-def _single(load_kn: float) -> AxleGroup:
-    return AxleGroup(
-        axle_count=1,
-        tyres_per_axle=2,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
-
-
-def _tandem(load_kn: float) -> AxleGroup:
-    return AxleGroup(
-        axle_count=2,
-        tyres_per_axle=4,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
+from ..conftest import make_single_axle, make_tandem_axle
 
 
 @pytest.fixture()
@@ -52,7 +31,7 @@ def fleet_d() -> TrafficInput:
     truck = MiningVehicle(
         name="Generic 100t Haul Truck",
         gross_vehicle_mass_t=100.0,
-        axle_groups=[_single(130.0), _tandem(520.0)],
+        axle_groups=[make_single_axle(130.0), make_tandem_axle(520.0)],
         source="bench_05 design fixture",
     )
     return TrafficInput(

--- a/tests/test_pavement/test_design.py
+++ b/tests/test_pavement/test_design.py
@@ -9,34 +9,10 @@ from __future__ import annotations
 import pytest
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
-from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.models.vehicle import MiningVehicle
 from haulpave.pavement import PavementResult, design_pavement
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
-
-_PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
-
-
-def _single(load_kn: float) -> AxleGroup:
-    """Single axle group: 1 axle, 2 tyres."""
-    return AxleGroup(
-        axle_count=1,
-        tyres_per_axle=2,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
-
-
-def _tandem(load_kn: float) -> AxleGroup:
-    """Tandem axle group: 2 axles, 4 tyres per axle (dual-tyre stations)."""
-    return AxleGroup(
-        axle_count=2,
-        tyres_per_axle=4,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
+from ..conftest import make_single_axle, make_tandem_axle
 
 
 @pytest.fixture()
@@ -46,8 +22,8 @@ def simple_traffic() -> TrafficInput:
         name="Test Truck",
         gross_vehicle_mass_t=100.0,
         axle_groups=[
-            _single(200.0),
-            _tandem(600.0),
+            make_single_axle(200.0),
+            make_tandem_axle(600.0),
         ],
         source="Unit test fixture",
     )
@@ -65,8 +41,8 @@ def fleet_b_traffic() -> TrafficInput:
         name="CAT 785D",
         gross_vehicle_mass_t=269.0,
         axle_groups=[
-            _single(225.0),
-            _tandem(1040.0),
+            make_single_axle(225.0),
+            make_tandem_axle(1040.0),
         ],
         source="Caterpillar 785D Specifications",
     )
@@ -74,8 +50,8 @@ def fleet_b_traffic() -> TrafficInput:
         name="Motor Grader (25 t)",
         gross_vehicle_mass_t=25.0,
         axle_groups=[
-            _single(85.0),
-            _tandem(160.0),
+            make_single_axle(85.0),
+            make_tandem_axle(160.0),
         ],
         source="Generic motor grader",
     )

--- a/tests/test_pavement/test_trh14.py
+++ b/tests/test_pavement/test_trh14.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
-from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.models.vehicle import MiningVehicle
 from haulpave.pavement.trh14 import (
     TRH14Result,
     _interpolate_catalog,
@@ -20,28 +20,7 @@ from haulpave.pavement.trh14 import (
     compute_trh14,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-_PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
-
-
-def _single(load_kn: float) -> AxleGroup:
-    return AxleGroup(
-        axle_count=1,
-        tyres_per_axle=2,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
-
-
-def _tandem(load_kn: float) -> AxleGroup:
-    return AxleGroup(
-        axle_count=2,
-        tyres_per_axle=4,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
+from ..conftest import make_single_axle, make_tandem_axle
 
 
 @pytest.fixture()
@@ -54,7 +33,7 @@ def fleet_d() -> TrafficInput:
     truck = MiningVehicle(
         name="Generic 100t Haul Truck",
         gross_vehicle_mass_t=100.0,
-        axle_groups=[_single(130.0), _tandem(520.0)],
+        axle_groups=[make_single_axle(130.0), make_tandem_axle(520.0)],
         source="bench_05 design fixture",
     )
     return TrafficInput(
@@ -186,7 +165,7 @@ class TestComputeTrh14CoverageClamping:
         truck = MiningVehicle(
             name="T",
             gross_vehicle_mass_t=10.0,
-            axle_groups=[_single(80.0)],
+            axle_groups=[make_single_axle(80.0)],
             source="test",
         )
         # 1 trip/day, 1 year, 10 days → very few coverages
@@ -206,7 +185,7 @@ class TestComputeTrh14CoverageClamping:
         truck = MiningVehicle(
             name="T",
             gross_vehicle_mass_t=300.0,
-            axle_groups=[_single(300.0), _tandem(1200.0)],
+            axle_groups=[make_single_axle(300.0), make_tandem_axle(1200.0)],
             source="test",
         )
         traffic_heavy = TrafficInput(

--- a/tests/test_traffic/test_cesa.py
+++ b/tests/test_traffic/test_cesa.py
@@ -7,51 +7,16 @@ import math
 import pytest
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
-from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+
 from haulpave.traffic.cesa import CesaResult, _lef_for_axle_group, compute_cesa
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
-
-
-def _single(load_kn: float) -> AxleGroup:
-    """Single axle (axle_count=1)."""
-    return AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=load_kn, tire_spec=_TIRE)
-
-
-def _tandem(load_kn: float) -> AxleGroup:
-    """Tandem axle group (axle_count=2)."""
-    return AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=load_kn, tire_spec=_TIRE)
-
-
-def _tridem(load_kn: float) -> AxleGroup:
-    """Tridem axle group (axle_count=3)."""
-    return AxleGroup(axle_count=3, tyres_per_axle=4, gross_load_kn=load_kn, tire_spec=_TIRE)
-
-
-def _make_vehicle(name: str, axle_groups: list[AxleGroup]) -> MiningVehicle:
-    return MiningVehicle(
-        name=name,
-        gross_vehicle_mass_t=50.0,
-        axle_groups=axle_groups,
-        source="Synthetic vehicle for unit tests",
-    )
-
-
-def _make_traffic(
-    vehicle: MiningVehicle,
-    trips: float = 10,
-    life_years: float = 10,
-    days_per_year: int = 350,
-) -> TrafficInput:
-    return TrafficInput(
-        fleet=[FleetUnit(vehicle=vehicle, trips_per_day=trips)],
-        design_life_years=life_years,
-        working_days_per_year=days_per_year,
-    )
+from ..conftest import (
+    make_single_axle,
+    make_tandem_axle,
+    make_tridem_axle,
+    make_vehicle,
+    make_traffic,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -64,43 +29,43 @@ class TestLefForAxleGroup:
 
     def test_standard_single_axle_lef_is_one(self) -> None:
         """Standard single axle (80 kN) must give LEF = 1.0."""
-        group = _single(80.0)
+        group = make_single_axle(80.0)
         assert math.isclose(_lef_for_axle_group(group), 1.0, rel_tol=1e-9)
 
     def test_standard_tandem_lef_is_two(self) -> None:
         """Standard tandem (160 kN total) must give LEF = 2.0."""
-        group = _tandem(160.0)
+        group = make_tandem_axle(160.0)
         assert math.isclose(_lef_for_axle_group(group), 2.0, rel_tol=1e-9)
 
     def test_standard_tridem_lef_is_three(self) -> None:
         """Standard tridem (240 kN total) must give LEF = 3.0."""
-        group = _tridem(240.0)
+        group = make_tridem_axle(240.0)
         assert math.isclose(_lef_for_axle_group(group), 3.0, rel_tol=1e-9)
 
     def test_fourth_power_scaling_single_axle(self) -> None:
         """Doubling single-axle load (80 → 160 kN) must give LEF = 16."""
-        group_base = _single(80.0)
-        group_2x = _single(160.0)
+        group_base = make_single_axle(80.0)
+        group_2x = make_single_axle(160.0)
         ratio = _lef_for_axle_group(group_2x) / _lef_for_axle_group(group_base)
         assert math.isclose(ratio, 16.0, rel_tol=1e-9)
 
     def test_fourth_power_scaling_tandem(self) -> None:
         """Doubling tandem load (160 → 320 kN) must give LEF ratio = 16."""
-        group_base = _tandem(160.0)
-        group_2x = _tandem(320.0)
+        group_base = make_tandem_axle(160.0)
+        group_2x = make_tandem_axle(320.0)
         ratio = _lef_for_axle_group(group_2x) / _lef_for_axle_group(group_base)
         assert math.isclose(ratio, 16.0, rel_tol=1e-9)
 
     def test_known_single_axle_cat_777g_front(self) -> None:
         """CAT 777G front axle 155 kN → LEF ≈ 14.0918 (bench_01 workings)."""
-        group = _single(155.0)
+        group = make_single_axle(155.0)
         expected = (155.0 / 80.0) ** 4
         assert math.isclose(_lef_for_axle_group(group), expected, rel_tol=1e-9)
         assert math.isclose(_lef_for_axle_group(group), 14.0918, rel_tol=1e-4)
 
     def test_known_tandem_cat_777g_rear(self) -> None:
         """CAT 777G rear tandem 760 kN → LEF ≈ 1018.1328 (bench_01 workings)."""
-        group = _tandem(760.0)
+        group = make_tandem_axle(760.0)
         expected = (760.0 / 160.0) ** 4 * 2
         assert math.isclose(_lef_for_axle_group(group), expected, rel_tol=1e-9)
         assert math.isclose(_lef_for_axle_group(group), 1018.1328, rel_tol=1e-4)
@@ -115,34 +80,34 @@ class TestCesaResultMetadata:
     """Tests for CesaResult fields and method labelling."""
 
     def test_returns_cesa_result(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         assert isinstance(result, CesaResult)
 
     def test_total_cesa_is_positive(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         assert result.total_cesa > 0
 
     def test_method_contains_aashto(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         assert "AASHTO" in result.method
 
     def test_method_contains_4th(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         assert "4th" in result.method or "4th" in result.method.lower()
 
     def test_confidence_is_benchmark_tested(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         assert result.confidence == "benchmark_tested"
 
     def test_result_is_immutable(self) -> None:
         """CesaResult is a frozen dataclass — mutation must raise."""
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         with pytest.raises((AttributeError, TypeError)):
             result.total_cesa = 0.0  # type: ignore[misc]
 
@@ -157,16 +122,16 @@ class TestCesaStandardAxle:
 
     def test_standard_single_axle_cesa(self) -> None:
         """Single vehicle, standard axle: CESA = trips × 1.0 × days × years."""
-        vehicle = _make_vehicle("Standard", [_single(80.0)])
-        traffic = _make_traffic(vehicle, trips=10, life_years=10, days_per_year=350)
+        vehicle = make_vehicle("Standard", [make_single_axle(80.0)])
+        traffic = make_traffic(vehicle, trips=10, life_years=10, days_per_year=350)
         result = compute_cesa(traffic)
         expected = 10 * 1.0 * 350 * 10  # 35000
         assert math.isclose(result.total_cesa, expected, rel_tol=1e-9)
 
     def test_single_vehicle_single_trip_one_year_one_day(self) -> None:
         """Minimal case: 1 trip/day, 1 year, 1 day → CESA = LEF."""
-        vehicle = _make_vehicle("Minimal", [_single(80.0)])
-        traffic = _make_traffic(vehicle, trips=1, life_years=1, days_per_year=1)
+        vehicle = make_vehicle("Minimal", [make_single_axle(80.0)])
+        traffic = make_traffic(vehicle, trips=1, life_years=1, days_per_year=1)
         result = compute_cesa(traffic)
         assert math.isclose(result.total_cesa, 1.0, rel_tol=1e-9)
 
@@ -181,39 +146,39 @@ class TestCesaScalingProperties:
 
     def test_linear_in_trips_per_day(self) -> None:
         """Doubling trips_per_day must double CESA."""
-        vehicle = _make_vehicle("V", [_single(100.0)])
-        r1 = compute_cesa(_make_traffic(vehicle, trips=10))
-        r2 = compute_cesa(_make_traffic(vehicle, trips=20))
+        vehicle = make_vehicle("V", [make_single_axle(100.0)])
+        r1 = compute_cesa(make_traffic(vehicle, trips=10))
+        r2 = compute_cesa(make_traffic(vehicle, trips=20))
         assert math.isclose(r2.total_cesa / r1.total_cesa, 2.0, rel_tol=1e-9)
 
     def test_linear_in_design_life(self) -> None:
         """Doubling design_life_years must double CESA."""
-        vehicle = _make_vehicle("V", [_single(100.0)])
-        r1 = compute_cesa(_make_traffic(vehicle, life_years=5))
-        r2 = compute_cesa(_make_traffic(vehicle, life_years=10))
+        vehicle = make_vehicle("V", [make_single_axle(100.0)])
+        r1 = compute_cesa(make_traffic(vehicle, life_years=5))
+        r2 = compute_cesa(make_traffic(vehicle, life_years=10))
         assert math.isclose(r2.total_cesa / r1.total_cesa, 2.0, rel_tol=1e-9)
 
     def test_linear_in_working_days(self) -> None:
         """Doubling working_days_per_year must double CESA."""
-        vehicle = _make_vehicle("V", [_single(100.0)])
-        r1 = compute_cesa(_make_traffic(vehicle, days_per_year=175))
-        r2 = compute_cesa(_make_traffic(vehicle, days_per_year=350))
+        vehicle = make_vehicle("V", [make_single_axle(100.0)])
+        r1 = compute_cesa(make_traffic(vehicle, days_per_year=175))
+        r2 = compute_cesa(make_traffic(vehicle, days_per_year=350))
         assert math.isclose(r2.total_cesa / r1.total_cesa, 2.0, rel_tol=1e-9)
 
     def test_fourth_power_single_axle_load(self) -> None:
         """Doubling single-axle load → CESA ratio = 16."""
-        v_base = _make_vehicle("Base", [_single(80.0)])
-        v_2x = _make_vehicle("2x", [_single(160.0)])
-        r_base = compute_cesa(_make_traffic(v_base, trips=10))
-        r_2x = compute_cesa(_make_traffic(v_2x, trips=10))
+        v_base = make_vehicle("Base", [make_single_axle(80.0)])
+        v_2x = make_vehicle("2x", [make_single_axle(160.0)])
+        r_base = compute_cesa(make_traffic(v_base, trips=10))
+        r_2x = compute_cesa(make_traffic(v_2x, trips=10))
         assert math.isclose(r_2x.total_cesa / r_base.total_cesa, 16.0, rel_tol=1e-9)
 
     def test_fourth_power_tandem_load(self) -> None:
         """Doubling tandem group load → CESA ratio = 16."""
-        v_base = _make_vehicle("Base", [_tandem(160.0)])
-        v_2x = _make_vehicle("2x", [_tandem(320.0)])
-        r_base = compute_cesa(_make_traffic(v_base, trips=10))
-        r_2x = compute_cesa(_make_traffic(v_2x, trips=10))
+        v_base = make_vehicle("Base", [make_tandem_axle(160.0)])
+        v_2x = make_vehicle("2x", [make_tandem_axle(320.0)])
+        r_base = compute_cesa(make_traffic(v_base, trips=10))
+        r_2x = compute_cesa(make_traffic(v_2x, trips=10))
         assert math.isclose(r_2x.total_cesa / r_base.total_cesa, 16.0, rel_tol=1e-9)
 
 
@@ -226,8 +191,8 @@ class TestMultiVehicleFleet:
     """CESA for a fleet must equal the sum of individual vehicle CESAs."""
 
     def test_two_vehicle_fleet_additivity(self) -> None:
-        v1 = _make_vehicle("V1", [_single(100.0)])
-        v2 = _make_vehicle("V2", [_tandem(200.0)])
+        v1 = make_vehicle("V1", [make_single_axle(100.0)])
+        v2 = make_vehicle("V2", [make_tandem_axle(200.0)])
         traffic_combined = TrafficInput(
             fleet=[
                 FleetUnit(vehicle=v1, trips_per_day=10),
@@ -238,14 +203,14 @@ class TestMultiVehicleFleet:
         )
         r_combined = compute_cesa(traffic_combined)
 
-        r1 = compute_cesa(_make_traffic(v1, trips=10))
-        r2 = compute_cesa(_make_traffic(v2, trips=5))
+        r1 = compute_cesa(make_traffic(v1, trips=10))
+        r2 = compute_cesa(make_traffic(v2, trips=5))
         assert math.isclose(r_combined.total_cesa, r1.total_cesa + r2.total_cesa, rel_tol=1e-9)
 
     def test_fleet_ordering_does_not_matter(self) -> None:
         """CESA must be the same regardless of FleetUnit order."""
-        v1 = _make_vehicle("V1", [_single(100.0)])
-        v2 = _make_vehicle("V2", [_tandem(200.0)])
+        v1 = make_vehicle("V1", [make_single_axle(100.0)])
+        v2 = make_vehicle("V2", [make_tandem_axle(200.0)])
         t_ab = TrafficInput(
             fleet=[
                 FleetUnit(vehicle=v1, trips_per_day=10),
@@ -277,19 +242,19 @@ class TestMultiAxleVehicle:
 
     def test_two_axle_groups_summed(self) -> None:
         """CESA from a 2-group vehicle must equal the sum of the two group CESAs."""
-        v_combined = _make_vehicle("Combined", [_single(100.0), _tandem(200.0)])
-        v_single_only = _make_vehicle("Single", [_single(100.0)])
-        v_tandem_only = _make_vehicle("Tandem", [_tandem(200.0)])
+        v_combined = make_vehicle("Combined", [make_single_axle(100.0), make_tandem_axle(200.0)])
+        v_single_only = make_vehicle("Single", [make_single_axle(100.0)])
+        v_tandem_only = make_vehicle("Tandem", [make_tandem_axle(200.0)])
 
-        r_combined = compute_cesa(_make_traffic(v_combined, trips=10))
-        r_s = compute_cesa(_make_traffic(v_single_only, trips=10))
-        r_t = compute_cesa(_make_traffic(v_tandem_only, trips=10))
+        r_combined = compute_cesa(make_traffic(v_combined, trips=10))
+        r_s = compute_cesa(make_traffic(v_single_only, trips=10))
+        r_t = compute_cesa(make_traffic(v_tandem_only, trips=10))
         assert math.isclose(r_combined.total_cesa, r_s.total_cesa + r_t.total_cesa, rel_tol=1e-9)
 
     def test_three_axle_groups(self) -> None:
         """A vehicle with three axle groups must compute a positive CESA."""
-        v = _make_vehicle("Triple", [_single(80.0), _tandem(160.0), _tridem(240.0)])
-        result = compute_cesa(_make_traffic(v, trips=1, life_years=1, days_per_year=1))
+        v = make_vehicle("Triple", [make_single_axle(80.0), make_tandem_axle(160.0), make_tridem_axle(240.0)])
+        result = compute_cesa(make_traffic(v, trips=1, life_years=1, days_per_year=1))
         # LEF: 1.0 + 2.0 + 3.0 = 6.0; CESA = 1 × 6.0 × 1 × 1 = 6.0
         assert math.isclose(result.total_cesa, 6.0, rel_tol=1e-9)
 
@@ -303,32 +268,32 @@ class TestEdgeCases:
     """Edge cases: single trip, very long design life, fractional days, etc."""
 
     def test_single_trip_per_day(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle, trips=1, life_years=1, days_per_year=365))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle, trips=1, life_years=1, days_per_year=365))
         assert math.isclose(result.total_cesa, 365.0, rel_tol=1e-9)
 
     def test_long_design_life(self) -> None:
         """50-year design life should give 5× the CESA of 10-year design life."""
-        vehicle = _make_vehicle("V", [_single(100.0)])
-        r10 = compute_cesa(_make_traffic(vehicle, life_years=10))
-        r50 = compute_cesa(_make_traffic(vehicle, life_years=50))
+        vehicle = make_vehicle("V", [make_single_axle(100.0)])
+        r10 = compute_cesa(make_traffic(vehicle, life_years=10))
+        r50 = compute_cesa(make_traffic(vehicle, life_years=50))
         assert math.isclose(r50.total_cesa / r10.total_cesa, 5.0, rel_tol=1e-9)
 
     def test_fractional_trips_per_day(self) -> None:
         """trips_per_day may be non-integer (e.g. 0.5 trucks/day)."""
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        r_half = compute_cesa(_make_traffic(vehicle, trips=0.5, life_years=10, days_per_year=350))
-        r_one = compute_cesa(_make_traffic(vehicle, trips=1.0, life_years=10, days_per_year=350))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        r_half = compute_cesa(make_traffic(vehicle, trips=0.5, life_years=10, days_per_year=350))
+        r_one = compute_cesa(make_traffic(vehicle, trips=1.0, life_years=10, days_per_year=350))
         assert math.isclose(r_half.total_cesa * 2, r_one.total_cesa, rel_tol=1e-9)
 
     def test_total_cesa_is_float(self) -> None:
-        vehicle = _make_vehicle("V", [_single(80.0)])
-        result = compute_cesa(_make_traffic(vehicle))
+        vehicle = make_vehicle("V", [make_single_axle(80.0)])
+        result = compute_cesa(make_traffic(vehicle))
         assert isinstance(result.total_cesa, float)
 
     def test_very_light_load(self) -> None:
         """Extremely light axle load (10 kN) must still give a positive CESA."""
-        vehicle = _make_vehicle("Light", [_single(10.0)])
-        result = compute_cesa(_make_traffic(vehicle, trips=1, life_years=1, days_per_year=1))
+        vehicle = make_vehicle("Light", [make_single_axle(10.0)])
+        result = compute_cesa(make_traffic(vehicle, trips=1, life_years=1, days_per_year=1))
         expected_lef = (10.0 / 80.0) ** 4
         assert math.isclose(result.total_cesa, expected_lef, rel_tol=1e-9)

--- a/tests/test_traffic/test_cesa.py
+++ b/tests/test_traffic/test_cesa.py
@@ -7,17 +7,15 @@ import math
 import pytest
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
-
 from haulpave.traffic.cesa import CesaResult, _lef_for_axle_group, compute_cesa
 
 from ..conftest import (
     make_single_axle,
     make_tandem_axle,
+    make_traffic,
     make_tridem_axle,
     make_vehicle,
-    make_traffic,
 )
-
 
 # ---------------------------------------------------------------------------
 # Tests: _lef_for_axle_group
@@ -253,7 +251,10 @@ class TestMultiAxleVehicle:
 
     def test_three_axle_groups(self) -> None:
         """A vehicle with three axle groups must compute a positive CESA."""
-        v = make_vehicle("Triple", [make_single_axle(80.0), make_tandem_axle(160.0), make_tridem_axle(240.0)])
+        v = make_vehicle(
+            "Triple",
+            [make_single_axle(80.0), make_tandem_axle(160.0), make_tridem_axle(240.0)],
+        )
         result = compute_cesa(make_traffic(v, trips=1, life_years=1, days_per_year=1))
         # LEF: 1.0 + 2.0 + 3.0 = 6.0; CESA = 1 × 6.0 × 1 × 1 = 6.0
         assert math.isclose(result.total_cesa, 6.0, rel_tol=1e-9)

--- a/tests/test_traffic/test_coverages.py
+++ b/tests/test_traffic/test_coverages.py
@@ -168,8 +168,12 @@ class TestDesignWheelLoad:
 
     def test_fleet_a_design_wheel_load(self) -> None:
         """Fleet A: 77.5 kN (CAT 777G front axle ÷ 2)."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
-        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])  # noqa: E501
+        cat_777g = _make_vehicle(
+            "CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)]
+        )  # noqa: E501
+        water_truck = _make_vehicle(
+            "Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)]
+        )  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -258,8 +262,12 @@ class TestComputeCoverages:
 
     def test_fleet_a_total_coverages(self) -> None:
         """Fleet A hand-calc: 771,523.33 coverages (±2%)."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
-        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])  # noqa: E501
+        cat_777g = _make_vehicle(
+            "CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)]
+        )  # noqa: E501
+        water_truck = _make_vehicle(
+            "Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)]
+        )  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -276,7 +284,9 @@ class TestComputeCoverages:
 
     def test_fleet_b_total_coverages(self) -> None:
         """Fleet B hand-calc: 530,357.24 coverages (±2%)."""
-        cat_785d = _make_vehicle("CAT 785D", 269.0, [make_single_axle(225.0), make_tandem_axle(1040.0)])  # noqa: E501
+        cat_785d = _make_vehicle(
+            "CAT 785D", 269.0, [make_single_axle(225.0), make_tandem_axle(1040.0)]
+        )  # noqa: E501
         motor_grader = _make_vehicle(
             "Motor Grader", 25.0, [make_single_axle(85.0), make_tandem_axle(160.0)]
         )
@@ -296,8 +306,12 @@ class TestComputeCoverages:
 
     def test_fleet_c_total_coverages(self) -> None:
         """Fleet C hand-calc: 268,531.80 coverages (±2%)."""
-        cat_793f = _make_vehicle("CAT 793F", 623.0, [make_single_axle(550.0), make_tandem_axle(1900.0)])  # noqa: E501
-        fuel_truck = _make_vehicle("Fuel Truck", 30.0, [make_single_axle(100.0), make_tandem_axle(200.0)])  # noqa: E501
+        cat_793f = _make_vehicle(
+            "CAT 793F", 623.0, [make_single_axle(550.0), make_tandem_axle(1900.0)]
+        )  # noqa: E501
+        fuel_truck = _make_vehicle(
+            "Fuel Truck", 30.0, [make_single_axle(100.0), make_tandem_axle(200.0)]
+        )  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_793f, trips_per_day=30),
@@ -314,8 +328,12 @@ class TestComputeCoverages:
 
     def test_design_wheel_load_fleet_a(self) -> None:
         """Fleet A design wheel load: 77.5 kN."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
-        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])  # noqa: E501
+        cat_777g = _make_vehicle(
+            "CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)]
+        )  # noqa: E501
+        water_truck = _make_vehicle(
+            "Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)]
+        )  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),

--- a/tests/test_traffic/test_coverages.py
+++ b/tests/test_traffic/test_coverages.py
@@ -150,7 +150,7 @@ class TestDesignWheelLoad:
 
     def test_picks_max_across_axle_groups(self) -> None:
         """Front axle load (77.5) > rear tandem load (47.5): design = 77.5."""
-        vehicle = _make_vehicle("V1", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
+        vehicle = _make_vehicle("V1", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=50)])
         assert math.isclose(_design_wheel_load_kn(traffic), 77.5, rel_tol=1e-9)
 
@@ -168,8 +168,8 @@ class TestDesignWheelLoad:
 
     def test_fleet_a_design_wheel_load(self) -> None:
         """Fleet A: 77.5 kN (CAT 777G front axle ÷ 2)."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
-        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])
+        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
+        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -258,8 +258,8 @@ class TestComputeCoverages:
 
     def test_fleet_a_total_coverages(self) -> None:
         """Fleet A hand-calc: 771,523.33 coverages (±2%)."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
-        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])
+        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
+        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -276,7 +276,7 @@ class TestComputeCoverages:
 
     def test_fleet_b_total_coverages(self) -> None:
         """Fleet B hand-calc: 530,357.24 coverages (±2%)."""
-        cat_785d = _make_vehicle("CAT 785D", 269.0, [make_single_axle(225.0), make_tandem_axle(1040.0)])
+        cat_785d = _make_vehicle("CAT 785D", 269.0, [make_single_axle(225.0), make_tandem_axle(1040.0)])  # noqa: E501
         motor_grader = _make_vehicle(
             "Motor Grader", 25.0, [make_single_axle(85.0), make_tandem_axle(160.0)]
         )
@@ -296,8 +296,8 @@ class TestComputeCoverages:
 
     def test_fleet_c_total_coverages(self) -> None:
         """Fleet C hand-calc: 268,531.80 coverages (±2%)."""
-        cat_793f = _make_vehicle("CAT 793F", 623.0, [make_single_axle(550.0), make_tandem_axle(1900.0)])
-        fuel_truck = _make_vehicle("Fuel Truck", 30.0, [make_single_axle(100.0), make_tandem_axle(200.0)])
+        cat_793f = _make_vehicle("CAT 793F", 623.0, [make_single_axle(550.0), make_tandem_axle(1900.0)])  # noqa: E501
+        fuel_truck = _make_vehicle("Fuel Truck", 30.0, [make_single_axle(100.0), make_tandem_axle(200.0)])  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_793f, trips_per_day=30),
@@ -314,8 +314,8 @@ class TestComputeCoverages:
 
     def test_design_wheel_load_fleet_a(self) -> None:
         """Fleet A design wheel load: 77.5 kN."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
-        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])
+        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])  # noqa: E501
+        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])  # noqa: E501
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),

--- a/tests/test_traffic/test_coverages.py
+++ b/tests/test_traffic/test_coverages.py
@@ -16,7 +16,7 @@ import math
 import pytest
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
-from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.models.vehicle import AxleGroup, MiningVehicle
 from haulpave.traffic.coverages import (
     CoveragesResult,
     _design_wheel_load_kn,
@@ -26,31 +26,7 @@ from haulpave.traffic.coverages import (
     compute_coverages,
 )
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
-
-_PLACEHOLDER_TIRE = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=50000.0)
-
-
-def _single_axle(load_kn: float) -> AxleGroup:
-    """Single axle: 1 axle, 2 tyres per axle."""
-    return AxleGroup(
-        axle_count=1,
-        tyres_per_axle=2,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
-
-
-def _tandem_axle(load_kn: float) -> AxleGroup:
-    """Tandem axle: 2 axles, 4 tyres per axle (dual-tyre stations)."""
-    return AxleGroup(
-        axle_count=2,
-        tyres_per_axle=4,
-        gross_load_kn=load_kn,
-        tire_spec=_PLACEHOLDER_TIRE,
-    )
+from ..conftest import PLACEHOLDER_TIRE, make_single_axle, make_tandem_axle
 
 
 def _make_vehicle(
@@ -111,27 +87,27 @@ class TestCoveragesResult:
 class TestWheelLoadKn:
     def test_single_axle_2tyres(self) -> None:
         """Single axle, 2 tyres, 155 kN → 77.5 kN/wheel."""
-        group = _single_axle(155.0)
+        group = make_single_axle(155.0)
         assert math.isclose(_wheel_load_kn(group), 77.5, rel_tol=1e-9)
 
     def test_single_axle_120kn(self) -> None:
         """Single axle, 2 tyres, 120 kN → 60.0 kN/wheel."""
-        group = _single_axle(120.0)
+        group = make_single_axle(120.0)
         assert math.isclose(_wheel_load_kn(group), 60.0, rel_tol=1e-9)
 
     def test_tandem_axle_760kn(self) -> None:
         """Tandem: 2 axles, 4 tyres/axle, 760 kN → 760/16 = 47.5 kN/wheel."""
-        group = _tandem_axle(760.0)
+        group = make_tandem_axle(760.0)
         assert math.isclose(_wheel_load_kn(group), 47.5, rel_tol=1e-9)
 
     def test_tandem_axle_1040kn(self) -> None:
         """Tandem: 2 axles, 4 tyres/axle, 1040 kN → 1040/16 = 65.0 kN/wheel."""
-        group = _tandem_axle(1040.0)
+        group = make_tandem_axle(1040.0)
         assert math.isclose(_wheel_load_kn(group), 65.0, rel_tol=1e-9)
 
     def test_tandem_axle_1900kn(self) -> None:
         """Tandem: 2 axles, 4 tyres/axle, 1900 kN → 1900/16 = 118.75 kN/wheel."""
-        group = _tandem_axle(1900.0)
+        group = make_tandem_axle(1900.0)
         assert math.isclose(_wheel_load_kn(group), 118.75, rel_tol=1e-9)
 
 
@@ -142,12 +118,12 @@ class TestWheelLoadKn:
 
 class TestWheelPositions:
     def test_single_axle_is_1(self) -> None:
-        group = _single_axle(100.0)
+        group = make_single_axle(100.0)
         assert _wheel_positions(group) == 1
 
     def test_tandem_axle_is_8(self) -> None:
         """Tandem: axle_count=2 * tyres_per_axle=4 = 8 positions."""
-        group = _tandem_axle(100.0)
+        group = make_tandem_axle(100.0)
         assert _wheel_positions(group) == 8
 
     def test_tridem_axle(self) -> None:
@@ -156,7 +132,7 @@ class TestWheelPositions:
             axle_count=3,
             tyres_per_axle=4,
             gross_load_kn=200.0,
-            tire_spec=_PLACEHOLDER_TIRE,
+            tire_spec=PLACEHOLDER_TIRE,
         )
         assert _wheel_positions(group) == 12
 
@@ -167,21 +143,21 @@ class TestWheelPositions:
 
 
 class TestDesignWheelLoad:
-    def test_single_vehicle_single_axle(self) -> None:
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(200.0)])
+    def test_single_vehicle_single_axle_design_wheel(self) -> None:
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(200.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)])
         assert math.isclose(_design_wheel_load_kn(traffic), 100.0, rel_tol=1e-9)
 
     def test_picks_max_across_axle_groups(self) -> None:
         """Front axle load (77.5) > rear tandem load (47.5): design = 77.5."""
-        vehicle = _make_vehicle("V1", 186.0, [_single_axle(155.0), _tandem_axle(760.0)])
+        vehicle = _make_vehicle("V1", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=50)])
         assert math.isclose(_design_wheel_load_kn(traffic), 77.5, rel_tol=1e-9)
 
     def test_picks_max_across_fleet(self) -> None:
         """Design load comes from the heaviest vehicle in the fleet."""
-        v1 = _make_vehicle("Light", 40.0, [_single_axle(120.0)])
-        v2 = _make_vehicle("Heavy", 186.0, [_single_axle(155.0)])
+        v1 = _make_vehicle("Light", 40.0, [make_single_axle(120.0)])
+        v2 = _make_vehicle("Heavy", 186.0, [make_single_axle(155.0)])
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=v1, trips_per_day=10),
@@ -192,8 +168,8 @@ class TestDesignWheelLoad:
 
     def test_fleet_a_design_wheel_load(self) -> None:
         """Fleet A: 77.5 kN (CAT 777G front axle ÷ 2)."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [_single_axle(155.0), _tandem_axle(760.0)])
-        water_truck = _make_vehicle("Water Truck", 40.0, [_single_axle(120.0), _tandem_axle(270.0)])
+        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
+        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -214,7 +190,7 @@ class TestEquivPassesPerDay:
         positions * trips_per_day * 2 equiv passes per day.
         Single axle: 1 position. 10 trips × 2 directions = 20 passes.
         """
-        group = _single_axle(200.0)
+        group = make_single_axle(200.0)
         design_wheel_load = 100.0  # 200/2 = 100 kN
         result = _equiv_passes_per_day(
             [group], trips_per_day=10, design_wheel_load=design_wheel_load
@@ -225,7 +201,7 @@ class TestEquivPassesPerDay:
         """wheel_load = 50, design = 100 → ratio^4 = (0.5)^4 = 1/16.
         1 position × (0.5)^4 × 10 trips × 2 dirs = 20/16 = 1.25.
         """
-        group = _single_axle(100.0)  # wheel_load = 50
+        group = make_single_axle(100.0)  # wheel_load = 50
         result = _equiv_passes_per_day([group], trips_per_day=10, design_wheel_load=100.0)
         assert math.isclose(result, 20.0 / 16.0, rel_tol=1e-9)
 
@@ -233,7 +209,7 @@ class TestEquivPassesPerDay:
         """CAT 777G front axle: positions=1, wheel=77.5, design=77.5.
         ratio^4 = 1.0. trips=50 × 2 × 1 = 100.
         """
-        group = _single_axle(155.0)
+        group = make_single_axle(155.0)
         result = _equiv_passes_per_day([group], trips_per_day=50, design_wheel_load=77.5)
         assert math.isclose(result, 100.0, rel_tol=1e-6)
 
@@ -241,7 +217,7 @@ class TestEquivPassesPerDay:
         """CAT 777G rear tandem: positions=8, wheel=47.5, design=77.5.
         ratio = 47.5/77.5. positions × ratio^4 × 50 × 2 = 8 × 0.141113 × 100 ≈ 112.89.
         """
-        group = _tandem_axle(760.0)
+        group = make_tandem_axle(760.0)
         result = _equiv_passes_per_day([group], trips_per_day=50, design_wheel_load=77.5)
         expected = 8 * (47.5 / 77.5) ** 4 * 50 * 2
         assert math.isclose(result, expected, rel_tol=1e-6)
@@ -254,22 +230,22 @@ class TestEquivPassesPerDay:
 
 class TestComputeCoverages:
     def test_returns_coverages_result(self) -> None:
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(100.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(100.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)])
         result = compute_coverages(traffic)
         assert isinstance(result, CoveragesResult)
 
     def test_method_contains_usace(self) -> None:
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(100.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(100.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)])
         result = compute_coverages(traffic)
         assert "USACE" in result.method or "coverage" in result.method.lower()
 
-    def test_single_vehicle_single_axle(self) -> None:
+    def test_single_vehicle_single_axle_coverages(self) -> None:
         """Single vehicle, single axle: design = vehicle wheel load.
         Ratio = 1.0, so coverages = trips × 2 × 1_position × working_days × years.
         """
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(200.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(200.0)])
         traffic = _make_traffic(
             [FleetUnit(vehicle=vehicle, trips_per_day=10)],
             design_life=5.0,
@@ -282,8 +258,8 @@ class TestComputeCoverages:
 
     def test_fleet_a_total_coverages(self) -> None:
         """Fleet A hand-calc: 771,523.33 coverages (±2%)."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [_single_axle(155.0), _tandem_axle(760.0)])
-        water_truck = _make_vehicle("Water Truck", 40.0, [_single_axle(120.0), _tandem_axle(270.0)])
+        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
+        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -300,9 +276,9 @@ class TestComputeCoverages:
 
     def test_fleet_b_total_coverages(self) -> None:
         """Fleet B hand-calc: 530,357.24 coverages (±2%)."""
-        cat_785d = _make_vehicle("CAT 785D", 269.0, [_single_axle(225.0), _tandem_axle(1040.0)])
+        cat_785d = _make_vehicle("CAT 785D", 269.0, [make_single_axle(225.0), make_tandem_axle(1040.0)])
         motor_grader = _make_vehicle(
-            "Motor Grader", 25.0, [_single_axle(85.0), _tandem_axle(160.0)]
+            "Motor Grader", 25.0, [make_single_axle(85.0), make_tandem_axle(160.0)]
         )
         traffic = _make_traffic(
             [
@@ -320,8 +296,8 @@ class TestComputeCoverages:
 
     def test_fleet_c_total_coverages(self) -> None:
         """Fleet C hand-calc: 268,531.80 coverages (±2%)."""
-        cat_793f = _make_vehicle("CAT 793F", 623.0, [_single_axle(550.0), _tandem_axle(1900.0)])
-        fuel_truck = _make_vehicle("Fuel Truck", 30.0, [_single_axle(100.0), _tandem_axle(200.0)])
+        cat_793f = _make_vehicle("CAT 793F", 623.0, [make_single_axle(550.0), make_tandem_axle(1900.0)])
+        fuel_truck = _make_vehicle("Fuel Truck", 30.0, [make_single_axle(100.0), make_tandem_axle(200.0)])
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_793f, trips_per_day=30),
@@ -338,8 +314,8 @@ class TestComputeCoverages:
 
     def test_design_wheel_load_fleet_a(self) -> None:
         """Fleet A design wheel load: 77.5 kN."""
-        cat_777g = _make_vehicle("CAT 777G", 186.0, [_single_axle(155.0), _tandem_axle(760.0)])
-        water_truck = _make_vehicle("Water Truck", 40.0, [_single_axle(120.0), _tandem_axle(270.0)])
+        cat_777g = _make_vehicle("CAT 777G", 186.0, [make_single_axle(155.0), make_tandem_axle(760.0)])
+        water_truck = _make_vehicle("Water Truck", 40.0, [make_single_axle(120.0), make_tandem_axle(270.0)])
         traffic = _make_traffic(
             [
                 FleetUnit(vehicle=cat_777g, trips_per_day=50),
@@ -351,7 +327,7 @@ class TestComputeCoverages:
 
     def test_coverages_scale_linearly_with_trips(self) -> None:
         """Doubling trips_per_day doubles total_coverages."""
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(200.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(200.0)])
         t1 = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)])
         t2 = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=20)])
         r1 = compute_coverages(t1)
@@ -360,7 +336,7 @@ class TestComputeCoverages:
 
     def test_coverages_scale_linearly_with_design_life(self) -> None:
         """Doubling design_life_years doubles total_coverages."""
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(200.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(200.0)])
         t1 = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)], design_life=5.0)
         t2 = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)], design_life=10.0)
         r1 = compute_coverages(t1)
@@ -369,8 +345,8 @@ class TestComputeCoverages:
 
     def test_fourth_power_weighting(self) -> None:
         """Half wheel load → coverage contribution reduced by factor 16 (0.5^4)."""
-        design_vehicle = _make_vehicle("Design", 30.0, [_single_axle(200.0)])
-        light_vehicle = _make_vehicle("Light", 15.0, [_single_axle(100.0)])
+        design_vehicle = _make_vehicle("Design", 30.0, [make_single_axle(200.0)])
+        light_vehicle = _make_vehicle("Light", 15.0, [make_single_axle(100.0)])
 
         t_design = _make_traffic([FleetUnit(vehicle=design_vehicle, trips_per_day=10)])
         t_mixed = _make_traffic(
@@ -388,13 +364,13 @@ class TestComputeCoverages:
         )
 
     def test_confidence_is_benchmark_tested(self) -> None:
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(100.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(100.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)])
         result = compute_coverages(traffic)
         assert result.confidence == "benchmark_tested"
 
     def test_positive_coverages(self) -> None:
-        vehicle = _make_vehicle("V1", 30.0, [_single_axle(100.0)])
+        vehicle = _make_vehicle("V1", 30.0, [make_single_axle(100.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=5)])
         result = compute_coverages(traffic)
         assert result.total_coverages > 0


### PR DESCRIPTION
Closes #56

Consolidate duplicated test helpers from 6 test files into `tests/conftest.py`:
- `make_single_axle`, `make_tandem_axle`, `make_tridem_axle` — AxleGroup factories
- `make_vehicle`, `make_traffic` — MiningVehicle/TrafficInput builders
- `PLACEHOLDER_TIRE` — shared TireSpec constant

Files consolidated: test_cesa.py, test_coverages.py, test_design.py, test_trh14.py, test_compare.py, bench_04_published_case.py

## Test plan
- [x] All 279 tests pass with refactored imports
- [x] No duplicate helper definitions remain
- [x] ruff check passes
- [x] mypy passes