### PR TITLE
[DAS-52] Add MkDocs API reference with mkdocstrings

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,63 @@
+# CLI Module
+
+Module: `src/haulpave/cli/`
+
+Command-line interface built with [Typer](https://typer.tiangolo.com/).
+
+---
+
+## Commands
+
+### `haulpave version`
+
+Print the HaulPave version.
+
+**Source:** `src/haulpave/cli/main.py:43`
+
+### `haulpave cesa --input <path> [--json]`
+
+Compute Cumulative Equivalent Standard Axles (CESA) from a traffic JSON file.
+
+**Source:** `src/haulpave/cli/main.py:57`
+
+| Option | Description |
+|--------|-------------|
+| `--input`, `-i` | Path to traffic JSON file |
+| `--json` | Output as formatted JSON (default: human-readable text) |
+
+### `haulpave coverages --input <path> [--json]`
+
+Compute design coverages (USACE TM 5-822-12) from a traffic JSON file.
+
+**Source:** `src/haulpave/cli/main.py:76`
+
+| Option | Description |
+|--------|-------------|
+| `--input`, `-i` | Path to traffic JSON file |
+| `--json` | Output as formatted JSON (default: human-readable text) |
+
+### `haulpave design --input <path> --cbr <value> [--curve-id <id>] [--json]`
+
+Design pavement thickness using the USACE CBR method.
+
+**Source:** `src/haulpave/cli/main.py:96`
+
+| Option | Description |
+|--------|-------------|
+| `--input`, `-i` | Path to traffic JSON file |
+| `--cbr` | Subgrade CBR [%] |
+| `--curve-id` | Curve dataset ID (default `"usace_cbr_v1"`) |
+| `--json` | Output as formatted JSON (default: human-readable text) |
+
+### `haulpave compare --input <path> --cbr <value> [--curve-id <id>] [--json]`
+
+Compare USACE CBR vs TRH 14 pavement design side-by-side.
+
+**Source:** `src/haulpave/cli/main.py:120`
+
+| Option | Description |
+|--------|-------------|
+| `--input`, `-i` | Path to traffic JSON file |
+| `--cbr` | Subgrade CBR [%] |
+| `--curve-id` | Curve dataset ID (default `"usace_cbr_v1"`) |
+| `--json` | Output as formatted JSON (default: human-readable text) |

--- a/docs/api/economics.md
+++ b/docs/api/economics.md
@@ -1,0 +1,129 @@
+# Economics Module
+
+Module: `src/haulpave/economics/`
+
+Scenario-based operating cost analysis for mine haul roads — single-scenario
+calculation and cross-surface rolling-resistance cost comparison.
+
+---
+
+## `compute_economics(scenario: CostScenario, trips_per_day: float = 0.0, working_days_per_year: int = 250) -> EconomicsResult`
+
+Compute operating cost for a haul road scenario using unit-cost summation
+per trip (fuel + tyre + maintenance + operator).
+
+**Source:** `src/haulpave/economics/engine.py:76`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scenario` | `CostScenario` | Haul geometry, fleet parameters, and cost assumptions |
+| `trips_per_day` | `float` | One-way trips per day (0 to skip annual calculation) |
+| `working_days_per_year` | `int` | Operating days per year (default 250) |
+
+**Returns:** `EconomicsResult`
+
+---
+
+## `EconomicsResult`
+
+```python
+@dataclass(frozen=True)
+class EconomicsResult:
+    scenario_id: str
+    cost_per_trip: float
+    cost_per_tonne_km: float
+    fuel_cost_per_trip: float
+    tyre_cost_per_trip: float
+    maintenance_cost_per_trip: float
+    operator_cost_per_trip: float
+    trips_per_year: float
+    annual_cost: float
+    currency: str
+    method: str = "haulpave-economics-v1"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+```
+
+**Source:** `src/haulpave/economics/engine.py:29`
+
+| Attribute | Description |
+|-----------|-------------|
+| `scenario_id` | Identifier from the input scenario |
+| `cost_per_trip` | Total cost per one-way trip [currency] |
+| `cost_per_tonne_km` | Unit transport cost [currency / (t·km)] |
+| `fuel_cost_per_trip` | Fuel component of cost per trip [currency] |
+| `tyre_cost_per_trip` | Tyre wear component of cost per trip [currency] |
+| `maintenance_cost_per_trip` | Maintenance component of cost per trip [currency] |
+| `operator_cost_per_trip` | Operator component of cost per trip [currency] |
+| `trips_per_year` | Annual trip count (0 if not provided) |
+| `annual_cost` | Annual operating cost (0 if not provided) |
+| `currency` | ISO 4217 currency code |
+| `method` | Human-readable method identifier |
+| `confidence` | Confidence label per project plan §4.3 |
+
+---
+
+## `to_economic_result(result: EconomicsResult) -> EconomicResult`
+
+Convert a detailed `EconomicsResult` dataclass to the Pydantic `EconomicResult` model.
+
+**Source:** `src/haulpave/economics/engine.py:132`
+
+---
+
+## `compare_scenarios(scenarios: list[RoadScenario], fuel_price_usd_per_litre: float = 0.80, working_days_per_year: int = 250) -> ComparisonResult`
+
+Compare annual operating costs across road surface scenarios using a
+rolling-resistance linear cost model.
+
+**Source:** `src/haulpave/economics/compare.py:81`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `scenarios` | `list[RoadScenario]` | Scenarios to compare (order preserved in output) |
+| `fuel_price_usd_per_litre` | `float` | Fuel price [USD/L] (default 0.80) |
+| `working_days_per_year` | `int` | Operating days per year (default 250) |
+
+**Returns:** `ComparisonResult`
+
+---
+
+## `RoadScenario`
+
+```python
+class RoadScenario(BaseModel):
+    name: str
+    surface: Literal["asphalt", "gravel", "concrete"]
+    thickness_mm: float  # Pavement design thickness [mm]
+    haul_distance_km: float  # One-way haul distance [km]
+    trips_per_day: float  # One-way vehicle trips per day
+```
+
+**Source:** `src/haulpave/economics/compare.py:47`
+
+---
+
+## `ScenarioComparison`
+
+```python
+class ScenarioComparison(BaseModel):
+    name: str
+    tire_cost_usd_per_year: float
+    fuel_cost_usd_per_year: float
+    maintenance_cost_usd_per_year: float
+    confidence: ConfidenceLabel = "experimental"
+```
+
+**Source:** `src/haulpave/economics/compare.py:59`
+
+---
+
+## `ComparisonResult`
+
+```python
+class ComparisonResult(BaseModel):
+    scenarios: list[ScenarioComparison]
+    method: str = "haulpave-economics-rr-v1"
+    confidence: ConfidenceLabel = "experimental"
+```
+
+**Source:** `src/haulpave/economics/compare.py:71`

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,202 @@
+# Models Module
+
+Module: `src/haulpave/models/`
+
+Pydantic data models for HaulPave. All models use SI units internally
+(mm, km, kN, kPa, tonnes) with explicit conversion at system boundaries.
+
+---
+
+## Vehicle Models
+
+### `TireSpec`
+
+**Source:** `src/haulpave/models/vehicle.py:11`
+
+```python
+class TireSpec(BaseModel, frozen=True):
+    contact_pressure_kpa: float  # Tyre contact pressure [kPa]
+    contact_area_mm2: float       # Tyre contact area [mm²]
+```
+
+### `AxleGroup`
+
+**Source:** `src/haulpave/models/vehicle.py:20`
+
+```python
+class AxleGroup(BaseModel, frozen=True):
+    axle_count: int       # Number of axles in group (1–4)
+    tyres_per_axle: int   # Tyres per axle (≥ 2)
+    gross_load_kn: float  # Total load on axle group [kN]
+    tire_spec: TireSpec
+```
+
+### `MiningVehicle`
+
+**Source:** `src/haulpave/models/vehicle.py:31`
+
+```python
+class MiningVehicle(BaseModel, frozen=True):
+    name: str                    # Vehicle make/model identifier
+    gross_vehicle_mass_t: float  # Gross vehicle mass [tonnes]
+    axle_groups: list[AxleGroup] # At least one axle group
+    source: str                  # Mandatory provenance — OEM spec sheet reference
+```
+
+---
+
+## Traffic Models
+
+### `FleetUnit`
+
+**Source:** `src/haulpave/models/traffic.py:15`
+
+```python
+class FleetUnit(BaseModel, frozen=True):
+    vehicle: MiningVehicle
+    trips_per_day: float  # One-way trips per day
+```
+
+### `HaulSegment`
+
+**Source:** `src/haulpave/models/traffic.py:24`
+
+```python
+class HaulSegment(BaseModel, frozen=True):
+    segment_id: str
+    length_km: float       # Segment length [km]
+    fleet: list[FleetUnit]
+```
+
+**Note:** This model is **experimental** — not yet benchmark-tested.
+
+### `TrafficInput`
+
+**Source:** `src/haulpave/models/traffic.py:49`
+
+```python
+class TrafficInput(BaseModel, frozen=True):
+    fleet: list[FleetUnit]      # Fleet mix for this section
+    design_life_years: float    # Pavement design life [years]
+    working_days_per_year: int  # Operating days per year (default 250)
+```
+
+### `TrafficResult`
+
+**Source:** `src/haulpave/models/traffic.py:67`
+
+```python
+class TrafficResult(BaseModel, frozen=True):
+    total_coverages: float   # Equivalent design coverages
+    total_esal: float        # Equivalent single-axle loads (AASHTO)
+    design_life_years: float
+    method: str              # Calculation method ID
+```
+
+---
+
+## Material Models
+
+### `MaterialLayer`
+
+**Source:** `src/haulpave/models/material.py:15`
+
+```python
+class MaterialLayer(BaseModel, frozen=True):
+    name: str                     # Material name / identifier
+    cbr_percent: float | None     # California Bearing Ratio [%]
+    elastic_modulus_kpa: float | None  # Elastic (resilient) modulus [kPa]
+    thickness_mm: float | None    # Layer thickness [mm]
+    is_template: bool             # True = indicative reference values only
+    source: str | None            # Provenance reference (required when is_template=True)
+```
+
+---
+
+## Pavement Models
+
+### `SubgradeInfo`
+
+**Source:** `src/haulpave/models/pavement.py:15`
+
+```python
+class SubgradeInfo(BaseModel, frozen=True):
+    cbr_percent: float         # In-situ subgrade CBR [%]
+    description: str | None    # Soil description or USCS class
+    source: str | None         # Test report or reference
+```
+
+### `PavementStructure`
+
+**Source:** `src/haulpave/models/pavement.py:25`
+
+```python
+class PavementStructure(BaseModel, frozen=True):
+    layers: list[MaterialLayer]  # Ordered layers, surface first
+
+    @computed_field
+    @property
+    def total_thickness_mm(self) -> float  # Sum of all specified layer thicknesses
+```
+
+### `DesignResult`
+
+**Source:** `src/haulpave/models/pavement.py:42`
+
+```python
+class DesignResult(BaseModel, frozen=True):
+    pavement_structure: PavementStructure
+    subgrade: SubgradeInfo
+    design_coverages: float
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    method_id: str          # e.g. "USACE-TM5-822-12"
+    package_version: str    # haul pave package version
+    curve_version: str | None
+    input_hash: str | None  # SHA-256 hex digest of serialised inputs
+```
+
+---
+
+## Economics Models
+
+### `CostAssumptions`
+
+**Source:** `src/haulpave/models/economics.py:12`
+
+```python
+class CostAssumptions(BaseModel, frozen=True):
+    fuel_cost_per_litre: float     # Fuel price [currency/L]
+    tyre_cost_per_hour: float      # Tyre wear cost [currency/hr]
+    maintenance_cost_per_km: float # Maintenance cost [currency/km]
+    operator_cost_per_hour: float  # Operator cost [currency/hr]
+    currency: str                  # ISO 4217 currency code (default "USD")
+```
+
+### `CostScenario`
+
+**Source:** `src/haulpave/models/economics.py:30`
+
+```python
+class CostScenario(BaseModel, frozen=True):
+    scenario_id: str
+    haul_distance_km: float              # One-way haul distance [km]
+    average_speed_kmh: float             # Average laden speed [km/h]
+    payload_t: float                     # Payload per trip [tonnes]
+    fuel_consumption_l_per_km: float     # Fuel consumption [L/km]
+    assumptions: CostAssumptions
+```
+
+### `EconomicResult`
+
+**Source:** `src/haulpave/models/economics.py:43`
+
+```python
+class EconomicResult(BaseModel, frozen=True):
+    scenario_id: str
+    cost_per_tonne_km: float  # Unit transport cost [currency/t·km]
+    cost_per_trip: float      # Total cost per one-way trip [currency]
+    trips_per_year: float     # Annual trip count
+    annual_cost: float        # Annual operating cost [currency]
+    currency: str             # ISO 4217 currency code
+    method: str               # Calculation method ID
+```

--- a/docs/api/pavement.md
+++ b/docs/api/pavement.md
@@ -1,0 +1,156 @@
+# Pavement Module
+
+Module: `src/haulpave/pavement/`
+
+Pavement thickness design engines — USACE TM 5-822-12 CBR method and
+TRH 14 (CSRA 1985) method, plus a side-by-side comparison engine.
+
+---
+
+## `design_pavement(traffic: TrafficInput, subgrade_cbr: float, curve_id: str = "usace_cbr_v1") -> PavementResult`
+
+Design pavement thickness using the USACE TM 5-822-12 CBR method.
+Pipeline: CESA → design coverages → CBR curve interpolation (PCHIP).
+
+**Source:** `src/haulpave/pavement/__init__.py:69`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `traffic` | `TrafficInput` | Fleet mix, design life, and working days |
+| `subgrade_cbr` | `float` | Subgrade CBR [%] |
+| `curve_id` | `str` | Digitized curve dataset identifier, e.g. `"usace_cbr_v1"` |
+
+**Returns:** `PavementResult`
+
+---
+
+## `PavementResult`
+
+```python
+@dataclass(frozen=True)
+class PavementResult:
+    total_cesa: float
+    total_coverages: float
+    required_thickness_mm: float
+    design_wheel_load_kn: float
+    method: str = "USACE TM 5-822-12 CBR design curves + AASHTO 4th-power LEF"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+```
+
+**Source:** `src/haulpave/pavement/__init__.py:40`
+
+| Attribute | Description |
+|-----------|-------------|
+| `total_cesa` | Cumulative Equivalent Standard Axles over the full design life |
+| `total_coverages` | Total equivalent design-wheel coverages over the full design life |
+| `required_thickness_mm` | Required total pavement thickness from the CBR design curve [mm] |
+| `design_wheel_load_kn` | Maximum single-wheel load in the fleet [kN] |
+| `method` | Human-readable method identifier |
+| `confidence` | Confidence label per project plan §4.3 |
+
+---
+
+## `cbr_thickness_from_coverages(subgrade_cbr: float, design_coverages: float, curve_id: str = "usace_cbr_v1") -> float`
+
+Return required CBR pavement thickness from pre-computed design coverages.
+Skips the CESA/coverages pipeline. Intended for the haul-calc JSON-RPC bridge.
+
+**Source:** `src/haulpave/pavement/__init__.py:128`
+
+---
+
+## `trh14_thickness_from_coverages(subgrade_cbr: float, design_coverages: float) -> TRH14Result`
+
+Return TRH 14 pavement thickness from subgrade CBR and pre-computed coverages.
+Adapter for the haul-calc JSON-RPC bridge.
+
+**Source:** `src/haulpave/pavement/__init__.py:158`
+
+---
+
+## `compute_trh14(traffic: TrafficInput, subgrade_cbr: float) -> TRH14Result`
+
+Design pavement thickness using the TRH 14 (CSRA 1985) method.
+Pipeline: design coverages → CBR-to-G-class → TRH 14 catalog lookup
+(log-linear interpolation on coverages axis).
+
+**Source:** `src/haulpave/pavement/trh14.py:191`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `traffic` | `TrafficInput` | Fleet mix, design life, and working days |
+| `subgrade_cbr` | `float` | Subgrade CBR [%] |
+
+**Returns:** `TRH14Result`
+
+---
+
+## `TRH14Result`
+
+```python
+@dataclass(frozen=True)
+class TRH14Result:
+    material_class: str
+    total_thickness_mm: float
+    total_coverages: float
+    design_wheel_load_kn: float
+    method: str = "TRH 14 (CSRA 1985) design catalog + USACE design-coverages"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+```
+
+**Source:** `src/haulpave/pavement/trh14.py:161`
+
+| Attribute | Description |
+|-----------|-------------|
+| `material_class` | TRH 14 G-class of the subgrade, e.g. `"G5"` |
+| `total_thickness_mm` | Required total compacted pavement thickness [mm] |
+| `total_coverages` | Total equivalent design-wheel coverages (USACE method) |
+| `design_wheel_load_kn` | Maximum single-wheel load in the fleet [kN] |
+| `method` | Human-readable method identifier |
+| `confidence` | Confidence label per project plan §4.3 |
+
+---
+
+## `cbr_to_material_class(cbr: float) -> str`
+
+Map subgrade CBR [%] to TRH 14 G-class material classification.
+Boundaries follow TRH 14 Table 2 (inclusive on the lower bound).
+
+**Source:** `src/haulpave/pavement/trh14.py:57`
+
+---
+
+## `compare_methods(traffic: TrafficInput, subgrade_cbr: float, curve_id: str = "usace_cbr_v1") -> ComparisonResult`
+
+Compare USACE TM 5-822-12 CBR and TRH 14 pavement design results side-by-side.
+Returns a `ComparisonResult` including the thickness delta.
+
+**Source:** `src/haulpave/pavement/compare.py:74`
+
+---
+
+## `ComparisonResult`
+
+```python
+@dataclass(frozen=True)
+class ComparisonResult:
+    usace: PavementResult
+    trh14: TRH14Result
+    delta_mm: float
+    subgrade_cbr: float
+    curve_id: str
+    method: str = "USACE TM 5-822-12 CBR vs TRH 14 (CSRA 1985) comparison"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+```
+
+**Source:** `src/haulpave/pavement/compare.py:39`
+
+| Attribute | Description |
+|-----------|-------------|
+| `usace` | Full result from the USACE CBR design path |
+| `trh14` | Full result from the TRH 14 design catalog path |
+| `delta_mm` | Thickness difference: TRH14 − USACE [mm] |
+| `subgrade_cbr` | Subgrade CBR [%] used for both calculations |
+| `curve_id` | USACE CBR curve dataset identifier |
+| `method` | Human-readable method identifier |
+| `confidence` | Confidence label (inherits `benchmark_tested` from sub-engines) |

--- a/docs/api/reporting.md
+++ b/docs/api/reporting.md
@@ -1,0 +1,37 @@
+# Reporting Module
+
+Module: `src/haulpave/reporting/`
+
+Versioned design summaries — wraps arbitrary design inputs and results in
+a metadata envelope for reproducibility.
+
+---
+
+## `build_design_summary(inputs: dict[str, Any], results: dict[str, Any] | None = None, title: str = "Haul Road Pavement Design Summary") -> DesignSummary`
+
+Build a versioned design summary from inputs and optional computed results.
+
+**Source:** `src/haulpave/reporting/summary.py:32`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `inputs` | `dict[str, Any]` | Arbitrary design inputs (fleet spec, pavement params, etc.) |
+| `results` | `dict[str, Any] \| None` | Computed outputs keyed by method name |
+| `title` | `str` | Human-readable summary title |
+
+**Returns:** `DesignSummary`
+
+---
+
+## `DesignSummary`
+
+```python
+class DesignSummary(BaseModel, frozen=True):
+    title: str                        # Summary title
+    generated_at: str                 # ISO 8601 UTC timestamp of generation
+    package_version: str              # haul pave package version string
+    inputs: dict[str, Any]           # Design inputs as passed by the caller
+    results: dict[str, Any]          # Computed results keyed by method name
+```
+
+**Source:** `src/haulpave/reporting/summary.py:20`

--- a/docs/api/traffic.md
+++ b/docs/api/traffic.md
@@ -1,0 +1,79 @@
+# Traffic Module
+
+Module: `src/haulpave/traffic/`
+
+CESA and design-coverages calculation engines for mine haul road traffic loading.
+
+---
+
+## `compute_cesa(traffic: TrafficInput) -> CesaResult`
+
+Compute Cumulative Equivalent Standard Axles using the AASHTO (1993) 4th-power
+Load Equivalency Factor (LEF) method.
+
+**Source:** `src/haulpave/traffic/cesa.py:88`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `traffic` | `TrafficInput` | Fleet mix, design life, and working days per year |
+
+**Returns:** `CesaResult` — frozen dataclass with `total_cesa`, `method`, and `confidence`.
+
+---
+
+## `CesaResult`
+
+```python
+@dataclass(frozen=True)
+class CesaResult:
+    total_cesa: float
+    method: str = "AASHTO 4th-power LEF (AASHTO 1993)"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+```
+
+**Source:** `src/haulpave/traffic/cesa.py:45`
+
+| Attribute | Description |
+|-----------|-------------|
+| `total_cesa` | Cumulative Equivalent Standard Axles over the full design life |
+| `method` | Human-readable method identifier |
+| `confidence` | Confidence label per project plan §4.3 |
+
+---
+
+## `compute_coverages(traffic: TrafficInput) -> CoveragesResult`
+
+Compute design coverages using the USACE TM 5-822-12 pass-count method.
+The design wheel load is the heaviest single-wheel load in the fleet; all other
+vehicles are weighted by the 4th power of the wheel-load ratio.
+
+**Source:** `src/haulpave/traffic/coverages.py:152`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `traffic` | `TrafficInput` | Fleet mix, design life, and working days per year |
+
+**Returns:** `CoveragesResult` — frozen dataclass with `total_coverages`,
+`design_wheel_load_kn`, `method`, and `confidence`.
+
+---
+
+## `CoveragesResult`
+
+```python
+@dataclass(frozen=True)
+class CoveragesResult:
+    total_coverages: float
+    design_wheel_load_kn: float
+    method: str = "USACE TM 5-822-12 pass-count method"
+    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+```
+
+**Source:** `src/haulpave/traffic/coverages.py:51`
+
+| Attribute | Description |
+|-----------|-------------|
+| `total_coverages` | Total equivalent design-wheel coverages over the full design life |
+| `design_wheel_load_kn` | Maximum single-wheel load in the fleet [kN] — the design vehicle |
+| `method` | Human-readable method identifier |
+| `confidence` | Confidence label per project plan §4.3 |

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,0 +1,44 @@
+# Utilities Module
+
+Module: `src/haulpave/utils/`
+
+Interpolation utilities for empirical curve data used in pavement thickness
+design.
+
+---
+
+## `load_curve_data(curve_id: str) -> dict[str, Any]`
+
+Load digitized curve JSON by curve identifier from the curves directory
+(`src/haulpave/design/curves/`).
+
+**Source:** `src/haulpave/utils/interpolation.py:16`
+
+| Parameter | Description |
+|-----------|-------------|
+| `curve_id` | Curve dataset identifier, e.g. `"usace_cbr_v1"` |
+
+**Returns:** Dictionary with `cbr_values`, `coverage_levels`, and `thickness_mm` keys.
+
+---
+
+## `interpolate_thickness(curve_data: dict[str, Any], cbr: float, coverages: float) -> float`
+
+Interpolate required pavement thickness for given CBR and design coverages
+using 2-step PCHIP interpolation:
+
+1. Interpolate thickness vs CBR at each coverage level.
+2. Log-linear interpolation between coverage levels.
+
+**Source:** `src/haulpave/utils/interpolation.py:58`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `curve_data` | `dict[str, Any]` | Loaded curve JSON (from `load_curve_data`) |
+| `cbr` | `float` | Subgrade CBR [%], must be within curve range |
+| `coverages` | `float` | Design coverages, must be > 0 |
+
+**Returns:** Required total pavement thickness [mm].
+
+**Raises:** `ValueError` if CBR is outside the supported range, coverages ≤ 0,
+or curve data is malformed.

--- a/docs/api/vehicle_registry.md
+++ b/docs/api/vehicle_registry.md
@@ -1,0 +1,51 @@
+# Vehicle Registry Module
+
+Module: `src/haulpave/vehicle_registry/`
+
+Canonical specifications for mining haul trucks — a catalogue of `VehicleEntry`
+records suitable for UI selection lists and seeding bridge scenarios.
+
+---
+
+## `list_all() -> list[VehicleEntry]`
+
+Return all registered vehicle entries.
+
+**Source:** `src/haulpave/vehicle_registry/__init__.py:104`
+
+---
+
+## `find_by_id(vehicle_id: str) -> VehicleEntry | None`
+
+Return the registry entry for `vehicle_id`, or `None` if not found.
+
+**Source:** `src/haulpave/vehicle_registry/__init__.py:109`
+
+---
+
+## `VehicleEntry`
+
+```python
+class VehicleEntry(BaseModel, frozen=True):
+    id: str            # Unique vehicle identifier slug
+    name: str          # Vehicle display name
+    gvw_kn: float      # Gross vehicle weight at rated payload [kN]
+    axles: int         # Number of axle groups
+    vehicle: MiningVehicle  # Full specification for engine use
+```
+
+**Source:** `src/haulpave/vehicle_registry/__init__.py:21`
+
+---
+
+## Registered Vehicles
+
+| ID | Name | GVW [kN] | Axle Groups |
+|----|------|----------|-------------|
+| `cat-797f` | Caterpillar 797F | 6,104 | 2 (front single, rear tandem) |
+| `cat-789d` | Caterpillar 789D | 3,304 | 2 (front single, rear tandem) |
+| `kom-960e` | Komatsu 960E | 5,925 | 2 (front single, rear tandem) |
+| `cat-785d` | Caterpillar 785D | 2,641 | 2 (front single, rear tandem) |
+
+All entries use a 25% front / 75% rear gross-weight split (CAT Performance
+Handbook Edition 47) and standard OTR tyre spec (700 kPa, 50,000 mm²).

--- a/docs/methodology/curve-encoding.md
+++ b/docs/methodology/curve-encoding.md
@@ -1,0 +1,129 @@
+# Curve Encoding Policy
+
+Several HaulPave design methods rely on graphical empirical curves rather than
+closed-form equations. Because digitisation introduces its own uncertainty,
+all encoded curves must comply with this policy.
+
+## Policy Overview
+
+| Requirement | Detail |
+|:------------|:--------|
+| **Source documentation** | Exact document, edition/year, page number, and figure/table number |
+| **Digitisation method** | Tool or method stated (e.g., WebPlotDigitizer 4.6, manual point extraction) |
+| **Stored representation** | Versioned JSON files of (x, y) control points |
+| **Companion metadata** | YAML file with full provenance (`.meta.yaml`) |
+| **Interpolation** | PCHIP default (`scipy.interpolate.PchipInterpolator`) |
+| **Tolerance** | Documented per curve (typically ±5 mm or ±10 %, whichever is greater) |
+| **Versioning** | Bump suffix on re-digitisation; previous versions retained |
+
+## Digitisation Policy
+
+Every encoded curve must satisfy these requirements:
+
+1. **Source documentation** — cite the exact source figure including document
+   title, edition/year, page number, and figure/table number.
+
+2. **Digitisation method** — record the tool or method used (e.g.,
+   WebPlotDigitizer 4.6, manual point extraction at standard knot intervals).
+   Control points must be extracted at sufficient density to capture all
+   curvature changes without aliasing.
+
+3. **Stored representation** — digitised curves are stored as versioned JSON
+   files in `src/haulpave/design/curves/`:
+   ```
+   src/haulpave/design/curves/
+   ├── <name>_v<N>.json          # Control point data
+   ├── <name>_v<N>.meta.yaml     # Provenance metadata
+   ```
+
+4. **Companion metadata** — every JSON file must have a `.meta.yaml` file with:
+   - `curve_id`: unique identifier matching the JSON filename
+   - `version`: semantic version string
+   - `source_document`: full citation of the source
+   - `figure`: exact figure/table reference
+   - `digitization_method`: tool and approach used
+   - `digitization_date`: ISO date of digitisation
+   - `digitized_by`: person or team who performed the digitisation
+   - `tolerance_mm`: expected absolute tolerance in mm
+   - `notes`: usage constraints, range limits, special handling
+   - `license`: source document copyright or public domain status
+
+5. **Interpolation method** — monotonic cubic spline
+   (`scipy.interpolate.PchipInterpolator`) is the default. The method is
+   recorded in the curve metadata and may be overridden if a different method
+   better fits the curve's behaviour.
+
+6. **Tolerance** — benchmark expected values are pinned to a specific curve
+   version. Acceptable deviation between HaulPave's interpolated result and a
+   hand-read value from the original chart is documented per curve (typically
+   ±5 mm or ±10 %, whichever is greater).
+
+## Interpolation: PCHIP
+
+HaulPave uses **Piecewise Cubic Hermite Interpolating Polynomial** (PCHIP)
+via `scipy.interpolate.PchipInterpolator` as the default interpolation method.
+
+Properties of PCHIP:
+- **Monotonicity-preserving** — will not overshoot between data points,
+  which is critical for design curves where physical relationships (e.g.,
+  higher CBR → less thickness) must be maintained.
+- **C¹ continuous** — first derivative is continuous, producing smooth
+  transitions between segments.
+- **Localised response** — changes in one region of the curve do not
+  propagate unphysically to distant regions.
+
+For the CBR thickness curves (`usace_cbr_v1`), interpolation proceeds in
+two steps:
+
+1. **CBR interpolation**: at each discrete coverage level, a PCHIP spline
+   is fitted over (`cbr_values`, `thickness_mm`). Thickness at the
+   requested CBR is evaluated from this spline.
+
+2. **Coverage interpolation**: the thickness values from step 1 are plotted
+   against log-transformed coverage levels. A second PCHIP spline over
+   `(log10(coverage), thickness)` yields the final thickness at the
+   requested coverage.
+
+Coverage values outside the curve's range are clamped to the boundary with a
+warning. CBR values outside the range raise `ValueError`.
+
+See `src/haulpave/utils/interpolation.py` for the implementation.
+
+## Curves
+
+### Currently Encoded
+
+| Curve | File | Source | Status |
+|:------|:-----|:-------|:-------|
+| USACE CBR curves | `usace_cbr_v1.json` + `.meta.yaml` | USACE TM 5-822-12, Figure 1 | Implemented (DAS-103) |
+| TRH 14 catalogue | `trh14_catalog_v1.json` | Thompson & Visser (2006), Table 3 | Catalog data added |
+
+### Adding a New Curve
+
+1. Digitise the source figure using a validated tool (e.g., WebPlotDigitizer).
+2. Record source, figure/table number, digitisation method, and tolerance in
+   the `.meta.yaml` companion file.
+3. Write unit tests in `tests/test_utils/test_interpolation.py` verifying
+   monotonicity and boundary behaviour.
+4. Bump the version suffix (`_v2`, `_v3`) on any re-digitisation.
+
+## Versioning
+
+Curve data files are versioned with a `_v<N>` suffix (e.g., `usace_cbr_v1.json`).
+The version number is bumped on any re-digitisation:
+
+- **v1 → v2**: re-digitised from the same source with higher fidelity
+- **v1 → v2**: digitised from a newer edition of the source document
+- Previous versions are retained in the repository for reproducibility.
+- Benchmarks reference a specific curve version via `load_curve_data("usace_cbr_v1")`.
+
+## Source Attribution
+
+All curve metadata must include the `source_document` field with a complete
+citation that allows an independent engineer to locate the original figure.
+Where the source document is in the public domain (e.g., US Government
+publications), note this in the `license` field. For copyrighted sources,
+include the copyright holder and permissions status.
+
+This policy is defined in the HaulPave Project Plan (Section 4.5) and is
+mandatory for all curve data committed to this repository.

--- a/examples/01_basic_pavement_design.py
+++ b/examples/01_basic_pavement_design.py
@@ -1,0 +1,96 @@
+"""Example 01: Basic Pavement Design — End-to-End Pipeline.
+
+Demonstrates the full pavement design workflow:
+1. Define a truck fleet with realistic vehicle specs
+2. Compute CESA (AASHTO 4th-power LEF)
+3. Compute design coverages (USACE TM 5-822-12 pass-count method)
+4. Design pavement thickness (USACE CBR curves)
+
+Run: python examples/01_basic_pavement_design.py
+"""
+
+from haulpave.models.traffic import FleetUnit, TrafficInput
+from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.traffic.cesa import compute_cesa
+from haulpave.traffic.coverages import compute_coverages
+from haulpave.pavement import design_pavement
+
+
+def main() -> None:
+    print("=" * 72)
+    print("EXAMPLE 01: Basic Pavement Design — End-to-End Pipeline")
+    print("=" * 72)
+
+    tire = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=5200.0)
+
+    haul_truck = MiningVehicle(
+        name="CAT 793F",
+        gross_vehicle_mass_t=623.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=550.0, tire_spec=tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=1900.0, tire_spec=tire),
+        ],
+        source="Caterpillar 793F spec sheet, 2023",
+    )
+
+    support_tire = TireSpec(contact_pressure_kpa=480.0, contact_area_mm2=3800.0)
+    fuel_truck = MiningVehicle(
+        name="Fuel Truck",
+        gross_vehicle_mass_t=30.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=100.0, tire_spec=support_tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=200.0, tire_spec=support_tire),
+        ],
+        source="Generic fuel truck spec",
+    )
+
+    traffic = TrafficInput(
+        fleet=[
+            FleetUnit(vehicle=haul_truck, trips_per_day=30.0),
+            FleetUnit(vehicle=fuel_truck, trips_per_day=15.0),
+        ],
+        design_life_years=10.0,
+        working_days_per_year=350,
+    )
+
+    print(f"\nFleet:")
+    for fu in traffic.fleet:
+        print(f"  {fu.vehicle.name}: {fu.trips_per_day} trips/day")
+
+    cesa_result = compute_cesa(traffic)
+    print(f"\n--- CESA (AASHTO 4th-power LEF) ---")
+    print(f"  Total CESA:       {cesa_result.total_cesa:,.2f}")
+    print(f"  Method:           {cesa_result.method}")
+    print(f"  Confidence:       {cesa_result.confidence}")
+
+    cov_result = compute_coverages(traffic)
+    print(f"\n--- Design Coverages (USACE TM 5-822-12) ---")
+    print(f"  Total coverages:  {cov_result.total_coverages:,.2f}")
+    print(f"  Design wheel load: {cov_result.design_wheel_load_kn:.1f} kN")
+    print(f"  Method:           {cov_result.method}")
+    print(f"  Confidence:       {cov_result.confidence}")
+
+    subgrade_cbr = 5.0
+    print(f"\n--- Pavement Thickness (USACE CBR Curves) ---")
+    print(f"  Subgrade CBR:     {subgrade_cbr}%")
+    try:
+        pv_result = design_pavement(traffic, subgrade_cbr=subgrade_cbr)
+        print(f"  Required thickness: {pv_result.required_thickness_mm:.1f} mm")
+        print(f"  Method:            {pv_result.method}")
+        print(f"  Confidence:        {pv_result.confidence}")
+    except ValueError as e:
+        print(f"  ERROR: {e}")
+        return
+
+    print(f"\n--- Summary ---")
+    print(f"  Design life:      {traffic.design_life_years} years")
+    print(f"  Working days/yr:  {traffic.working_days_per_year}")
+    print(f"  CESA:             {cesa_result.total_cesa:,.0f}")
+    print(f"  Coverages:        {cov_result.total_coverages:,.0f}")
+    print(f"  Pavement:         {pv_result.required_thickness_mm:.0f} mm @ CBR {subgrade_cbr}%")
+
+    print(f"\nExample 01 completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_trh14_vs_usace_comparison.py
+++ b/examples/02_trh14_vs_usace_comparison.py
@@ -1,0 +1,78 @@
+"""Example 02: TRH 14 vs USACE Method Comparison.
+
+Compares pavement design thickness from two methods side-by-side
+for the same traffic input at 3 different subgrade CBR values:
+- USACE TM 5-822-12 CBR design curves
+- TRH 14 (CSRA 1985) design catalog
+
+Run: python examples/02_trh14_vs_usace_comparison.py
+"""
+
+from haulpave.models.traffic import FleetUnit, TrafficInput
+from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.pavement.compare import compare_methods
+
+
+def main() -> None:
+    print("=" * 72)
+    print("EXAMPLE 02: TRH 14 vs USACE Method Comparison")
+    print("=" * 72)
+
+    tire = TireSpec(contact_pressure_kpa=700.0, contact_area_mm2=5200.0)
+
+    haul_truck = MiningVehicle(
+        name="CAT 793F",
+        gross_vehicle_mass_t=623.0,
+        axle_groups=[
+            AxleGroup(axle_count=1, tyres_per_axle=2, gross_load_kn=550.0, tire_spec=tire),
+            AxleGroup(axle_count=2, tyres_per_axle=4, gross_load_kn=1900.0, tire_spec=tire),
+        ],
+        source="Caterpillar 793F spec sheet, 2023",
+    )
+
+    traffic = TrafficInput(
+        fleet=[FleetUnit(vehicle=haul_truck, trips_per_day=30.0)],
+        design_life_years=10.0,
+        working_days_per_year=350,
+    )
+
+    print(f"\nFleet: {traffic.fleet[0].vehicle.name} @ {traffic.fleet[0].trips_per_day} trips/day")
+    print(f"Design life: {traffic.design_life_years} years, {traffic.working_days_per_year} days/yr")
+    print()
+
+    cbr_values = [3.0, 5.0, 10.0]
+
+    print(f"{'CBR':>5}  {'USACE (mm)':>12}  {'TRH 14 (mm)':>12}  {'Delta (mm)':>12}  {'G-Class':>8}")
+    print(f"{'-'*5}  {'-'*12}  {'-'*12}  {'-'*12}  {'-'*8}")
+
+    for cbr in cbr_values:
+        try:
+            result = compare_methods(traffic, subgrade_cbr=cbr)
+            usace_thk = result.usace.required_thickness_mm
+            trh14_thk = result.trh14.total_thickness_mm
+            delta = result.delta_mm
+            g_class = result.trh14.material_class
+            print(f"{cbr:5.1f}  {usace_thk:12.1f}  {trh14_thk:12.1f}  {delta:+12.1f}  {g_class:>8}")
+        except ValueError as e:
+            print(f"{cbr:5.1f}  {'ERROR':>12}  {'ERROR':>12}  {'ERROR':>12}  {str(e)[:20]:>8}")
+
+    print(f"\nMethod: {compare_methods.__doc__.strip().split(chr(10))[0]}")
+
+    cbr_result = compare_methods(traffic, subgrade_cbr=5.0)
+    print(f"\n--- Detail at CBR 5% ---")
+    print(f"  USACE:")
+    print(f"    CESA:           {cbr_result.usace.total_cesa:,.0f}")
+    print(f"    Coverages:      {cbr_result.usace.total_coverages:,.0f}")
+    print(f"    Design wheel:   {cbr_result.usace.design_wheel_load_kn:.1f} kN")
+    print(f"    Thickness:      {cbr_result.usace.required_thickness_mm:.1f} mm")
+    print(f"  TRH 14:")
+    print(f"    Material class: {cbr_result.trh14.material_class}")
+    print(f"    Coverages:      {cbr_result.trh14.total_coverages:,.0f}")
+    print(f"    Thickness:      {cbr_result.trh14.total_thickness_mm:.1f} mm")
+    print(f"  Delta (TRH14 - USACE): {cbr_result.delta_mm:+.1f} mm")
+
+    print(f"\nExample 02 completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_economics_scenario.py
+++ b/examples/03_economics_scenario.py
@@ -1,0 +1,105 @@
+"""Example 03: Economics Scenario — Operating Cost & Rolling Resistance.
+
+Demonstrates two economics calculations:
+1. Unit-cost economics: fleet definition -> cost per trip, cost per tonne-km
+2. Rolling resistance scenario comparison: asphalt vs gravel vs concrete surfaces
+
+Run: python examples/03_economics_scenario.py
+"""
+
+from haulpave.models.economics import CostAssumptions, CostScenario
+from haulpave.economics.engine import compute_economics as compute_operating_cost
+from haulpave.economics.compare import RoadScenario, compare_scenarios
+
+
+def main() -> None:
+    print("=" * 72)
+    print("EXAMPLE 03: Economics — Operating Cost & Rolling Resistance")
+    print("=" * 72)
+
+    print("\n--- Part 1: Unit-Cost Operating Cost ---")
+    assumptions = CostAssumptions(
+        fuel_cost_per_litre=0.80,
+        tyre_cost_per_hour=45.0,
+        maintenance_cost_per_km=0.35,
+        operator_cost_per_hour=38.0,
+        currency="USD",
+    )
+
+    scenario = CostScenario(
+        scenario_id="haul_road_main",
+        haul_distance_km=5.0,
+        average_speed_kmh=35.0,
+        payload_t=150.0,
+        fuel_consumption_l_per_km=2.5,
+        assumptions=assumptions,
+    )
+
+    econ = compute_operating_cost(scenario, trips_per_day=40.0, working_days_per_year=250)
+
+    print(f"  Scenario:           {econ.scenario_id}")
+    print(f"  Cost per trip:      ${econ.cost_per_trip:,.2f}")
+    print(f"  Cost per tonne-km:  ${econ.cost_per_tonne_km:.4f}")
+    print(f"  Breakdown (per trip):")
+    print(f"    Fuel:             ${econ.fuel_cost_per_trip:,.2f}")
+    print(f"    Tyre:             ${econ.tyre_cost_per_trip:,.2f}")
+    print(f"    Maintenance:      ${econ.maintenance_cost_per_trip:,.2f}")
+    print(f"    Operator:         ${econ.operator_cost_per_trip:,.2f}")
+    print(f"  Annual cost:        ${econ.annual_cost:,.2f}")
+    print(f"  Trips per year:     {econ.trips_per_year:,.0f}")
+    print(f"  Currency:           {econ.currency}")
+    print(f"  Confidence:         {econ.confidence}")
+
+    print("\n--- Part 2: Rolling Resistance Scenario Comparison ---")
+
+    roads = [
+        RoadScenario(
+            name="Asphalt",
+            surface="asphalt",
+            thickness_mm=450.0,
+            haul_distance_km=5.0,
+            trips_per_day=40.0,
+        ),
+        RoadScenario(
+            name="Gravel",
+            surface="gravel",
+            thickness_mm=500.0,
+            haul_distance_km=5.0,
+            trips_per_day=40.0,
+        ),
+        RoadScenario(
+            name="Concrete",
+            surface="concrete",
+            thickness_mm=400.0,
+            haul_distance_km=5.0,
+            trips_per_day=40.0,
+        ),
+    ]
+
+    comp = compare_scenarios(
+        roads,
+        fuel_price_usd_per_litre=0.80,
+        working_days_per_year=250,
+    )
+
+    print(f"{'Surface':>10}  {'Fuel ($/yr)':>14}  {'Tyres ($/yr)':>14}  {'Maint ($/yr)':>14}  {'Total ($/yr)':>14}")
+    print(f"{'-'*10}  {'-'*14}  {'-'*14}  {'-'*14}  {'-'*14}")
+
+    for sc in comp.scenarios:
+        total = sc.fuel_cost_usd_per_year + sc.tire_cost_usd_per_year + sc.maintenance_cost_usd_per_year
+        print(
+            f"{sc.name:>10}  {sc.fuel_cost_usd_per_year:>14,.0f}  "
+            f"{sc.tire_cost_usd_per_year:>14,.0f}  "
+            f"{sc.maintenance_cost_usd_per_year:>14,.0f}  "
+            f"{total:>14,.0f}"
+        )
+
+    print(f"\n  Method:     {comp.method}")
+    print(f"  Confidence: {comp.confidence}")
+    print(f"  (Gravel should be highest, concrete lowest)")
+
+    print(f"\nExample 03 completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,15 @@ theme:
 
 nav:
   - Home: index.md
+  - API Reference:
+    - Traffic: api/traffic.md
+    - Pavement: api/pavement.md
+    - Economics: api/economics.md
+    - Models: api/models.md
+    - Reporting: api/reporting.md
+    - Vehicle Registry: api/vehicle_registry.md
+    - Utilities: api/utils.md
+    - CLI: api/cli.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Closes #52

Adds API reference pages for all public subpackages under docs/api/:
- traffic, pavement, economics, models, reporting, vehicle_registry, utils, CLI

Updates mkdocs.yml nav with structured API reference section.

## Test plan
- [x] `mkdocs build --strict` passes without errors
- [x] ruff + mypy pass