### PR TITLE
[DAS-53] Create examples/ directory with end-to-end scripts

### DIFF
--- a/examples/01_basic_pavement_design.py
+++ b/examples/01_basic_pavement_design.py
@@ -11,9 +11,9 @@ Run: python examples/01_basic_pavement_design.py
 
 from haulpave.models.traffic import FleetUnit, TrafficInput
 from haulpave.models.vehicle import AxleGroup, MiningVehicle, TireSpec
+from haulpave.pavement import design_pavement
 from haulpave.traffic.cesa import compute_cesa
 from haulpave.traffic.coverages import compute_coverages
-from haulpave.pavement import design_pavement
 
 
 def main() -> None:
@@ -53,25 +53,25 @@ def main() -> None:
         working_days_per_year=350,
     )
 
-    print(f"\nFleet:")
+    print("\nFleet:")
     for fu in traffic.fleet:
         print(f"  {fu.vehicle.name}: {fu.trips_per_day} trips/day")
 
     cesa_result = compute_cesa(traffic)
-    print(f"\n--- CESA (AASHTO 4th-power LEF) ---")
+    print("\n--- CESA (AASHTO 4th-power LEF) ---")
     print(f"  Total CESA:       {cesa_result.total_cesa:,.2f}")
     print(f"  Method:           {cesa_result.method}")
     print(f"  Confidence:       {cesa_result.confidence}")
 
     cov_result = compute_coverages(traffic)
-    print(f"\n--- Design Coverages (USACE TM 5-822-12) ---")
+    print("\n--- Design Coverages (USACE TM 5-822-12) ---")
     print(f"  Total coverages:  {cov_result.total_coverages:,.2f}")
     print(f"  Design wheel load: {cov_result.design_wheel_load_kn:.1f} kN")
     print(f"  Method:           {cov_result.method}")
     print(f"  Confidence:       {cov_result.confidence}")
 
     subgrade_cbr = 5.0
-    print(f"\n--- Pavement Thickness (USACE CBR Curves) ---")
+    print("\n--- Pavement Thickness (USACE CBR Curves) ---")
     print(f"  Subgrade CBR:     {subgrade_cbr}%")
     try:
         pv_result = design_pavement(traffic, subgrade_cbr=subgrade_cbr)
@@ -82,14 +82,14 @@ def main() -> None:
         print(f"  ERROR: {e}")
         return
 
-    print(f"\n--- Summary ---")
+    print("\n--- Summary ---")
     print(f"  Design life:      {traffic.design_life_years} years")
     print(f"  Working days/yr:  {traffic.working_days_per_year}")
     print(f"  CESA:             {cesa_result.total_cesa:,.0f}")
     print(f"  Coverages:        {cov_result.total_coverages:,.0f}")
     print(f"  Pavement:         {pv_result.required_thickness_mm:.0f} mm @ CBR {subgrade_cbr}%")
 
-    print(f"\nExample 01 completed successfully.")
+    print("\nExample 01 completed successfully.")
 
 
 if __name__ == "__main__":

--- a/examples/02_trh14_vs_usace_comparison.py
+++ b/examples/02_trh14_vs_usace_comparison.py
@@ -59,19 +59,19 @@ def main() -> None:
     print(f"\nMethod: {compare_methods.__doc__.strip().split(chr(10))[0]}")
 
     cbr_result = compare_methods(traffic, subgrade_cbr=5.0)
-    print(f"\n--- Detail at CBR 5% ---")
-    print(f"  USACE:")
+    print("\n--- Detail at CBR 5% ---")
+    print("  USACE:")
     print(f"    CESA:           {cbr_result.usace.total_cesa:,.0f}")
     print(f"    Coverages:      {cbr_result.usace.total_coverages:,.0f}")
     print(f"    Design wheel:   {cbr_result.usace.design_wheel_load_kn:.1f} kN")
     print(f"    Thickness:      {cbr_result.usace.required_thickness_mm:.1f} mm")
-    print(f"  TRH 14:")
+    print("  TRH 14:")
     print(f"    Material class: {cbr_result.trh14.material_class}")
     print(f"    Coverages:      {cbr_result.trh14.total_coverages:,.0f}")
     print(f"    Thickness:      {cbr_result.trh14.total_thickness_mm:.1f} mm")
     print(f"  Delta (TRH14 - USACE): {cbr_result.delta_mm:+.1f} mm")
 
-    print(f"\nExample 02 completed successfully.")
+    print("\nExample 02 completed successfully.")
 
 
 if __name__ == "__main__":

--- a/examples/03_economics_scenario.py
+++ b/examples/03_economics_scenario.py
@@ -7,9 +7,9 @@ Demonstrates two economics calculations:
 Run: python examples/03_economics_scenario.py
 """
 
-from haulpave.models.economics import CostAssumptions, CostScenario
-from haulpave.economics.engine import compute_economics as compute_operating_cost
 from haulpave.economics.compare import RoadScenario, compare_scenarios
+from haulpave.economics.engine import compute_economics as compute_operating_cost
+from haulpave.models.economics import CostAssumptions, CostScenario
 
 
 def main() -> None:
@@ -40,7 +40,7 @@ def main() -> None:
     print(f"  Scenario:           {econ.scenario_id}")
     print(f"  Cost per trip:      ${econ.cost_per_trip:,.2f}")
     print(f"  Cost per tonne-km:  ${econ.cost_per_tonne_km:.4f}")
-    print(f"  Breakdown (per trip):")
+    print("  Breakdown (per trip):")
     print(f"    Fuel:             ${econ.fuel_cost_per_trip:,.2f}")
     print(f"    Tyre:             ${econ.tyre_cost_per_trip:,.2f}")
     print(f"    Maintenance:      ${econ.maintenance_cost_per_trip:,.2f}")
@@ -96,9 +96,9 @@ def main() -> None:
 
     print(f"\n  Method:     {comp.method}")
     print(f"  Confidence: {comp.confidence}")
-    print(f"  (Gravel should be highest, concrete lowest)")
+    print("  (Gravel should be highest, concrete lowest)")
 
-    print(f"\nExample 03 completed successfully.")
+    print("\nExample 03 completed successfully.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #53

Creates 3 end-to-end example scripts:
1. `01_basic_pavement_design.py` — CESA → coverages → USACE CBR thickness
2. `02_trh14_vs_usace_comparison.py` — TRH 14 vs USACE side-by-side
3. `03_economics_scenario.py` — Fleet economics + RR comparison

All scripts use `pip install haulpave` compatible imports.

## Test plan
- [x] All 3 scripts run without errors
- [x] ruff + mypy pass