### PR TITLE
[DAS-67] Fix cyclical import in pavement/__init__.py

### DIFF
--- a/src/haulpave/pavement/__init__.py
+++ b/src/haulpave/pavement/__init__.py
@@ -19,7 +19,10 @@ References
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from haulpave.pavement.trh14 import TRH14Result
 
 from haulpave.models.traffic import TrafficInput
 from haulpave.traffic.cesa import compute_cesa
@@ -214,8 +217,14 @@ def trh14_thickness_from_coverages(
     )
 
 
-# Type alias kept at module level to avoid circular import in annotations above
-# Bottom import — avoids circular dependency: compare.py imports PavementResult
-# and design_pavement from this module (already defined above by this point).
-from haulpave.pavement.compare import ComparisonResult, compare_methods  # noqa: E402
-from haulpave.pavement.trh14 import TRH14Result  # noqa: E402
+
+def __getattr__(name: str) -> Any:
+    """Lazy re-export to break circular import between this module and compare."""
+    if name in ("ComparisonResult", "compare_methods"):
+        import haulpave.pavement.compare as _mod
+        return getattr(_mod, name)
+    if name == "TRH14Result":
+        from haulpave.pavement.trh14 import TRH14Result
+        return TRH14Result
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/haulpave/pavement/__init__.py
+++ b/src/haulpave/pavement/__init__.py
@@ -217,14 +217,15 @@ def trh14_thickness_from_coverages(
     )
 
 
-
 def __getattr__(name: str) -> Any:
     """Lazy re-export to break circular import between this module and compare."""
     if name in ("ComparisonResult", "compare_methods"):
         import haulpave.pavement.compare as _mod
+
         return getattr(_mod, name)
     if name == "TRH14Result":
         from haulpave.pavement.trh14 import TRH14Result
+
         return TRH14Result
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/src/haulpave/pavement/compare.py
+++ b/src/haulpave/pavement/compare.py
@@ -24,11 +24,13 @@ References
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from haulpave.models.traffic import TrafficInput
-from haulpave.pavement import PavementResult, design_pavement
 from haulpave.pavement.trh14 import TRH14Result, compute_trh14
+
+if TYPE_CHECKING:
+    from haulpave.pavement import PavementResult
 
 __all__ = ["ComparisonResult", "compare_methods"]
 
@@ -103,6 +105,8 @@ def compare_methods(
         Propagated from either sub-engine — e.g. CBR out of USACE curve
         range, or G8/G9 subgrade (CBR < 2%) not in TRH 14 catalog.
     """
+    from haulpave.pavement import design_pavement
+
     usace_result = design_pavement(traffic, subgrade_cbr, curve_id)
     trh14_result = compute_trh14(traffic, subgrade_cbr)
     delta = trh14_result.total_thickness_mm - usace_result.required_thickness_mm


### PR DESCRIPTION
Closes #67

Eliminates bottom-of-file circular import workaround in pavement/__init__.py by using lazy imports inside function bodies.

## Test plan
- [x] `pytest` — 289 tests pass
- [x] `ruff` — clean
- [x] `mypy` — clean