### PR TITLE
[DAS-68] Add Excel export for economics scenarios

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
 docs = [
     "mkdocs-material>=9.5",
 ]
+excel = [
+    "openpyxl>=3.1",
+]
 
 [project.scripts]
 haulpave = "haulpave.cli.main:app"

--- a/src/haulpave/economics/__init__.py
+++ b/src/haulpave/economics/__init__.py
@@ -1,7 +1,8 @@
 """Economics module — scenario-based operating cost analysis.
 
-Provides ``compute_economics`` for single-scenario cost calculation and
-``compare_scenarios`` for cross-surface RR-based cost comparison.
+Provides ``compute_economics`` for single-scenario cost calculation,
+``compare_scenarios`` for cross-surface RR-based cost comparison, and
+``export_comparison_to_excel`` for exporting results to Excel.
 """
 
 from haulpave.economics.compare import (
@@ -11,6 +12,7 @@ from haulpave.economics.compare import (
     compare_scenarios,
 )
 from haulpave.economics.engine import EconomicsResult, compute_economics, to_economic_result
+from haulpave.economics.export import export_comparison_to_excel
 
 __all__ = [
     "ComparisonResult",
@@ -19,5 +21,6 @@ __all__ = [
     "ScenarioComparison",
     "compare_scenarios",
     "compute_economics",
+    "export_comparison_to_excel",
     "to_economic_result",
 ]

--- a/src/haulpave/economics/export.py
+++ b/src/haulpave/economics/export.py
@@ -26,8 +26,8 @@ def export_comparison_to_excel(comparison: ComparisonResult, filepath: str | Pat
     str
         The resolved absolute path of the created file.
     """
-    import openpyxl
-    from openpyxl.styles import Alignment, Font, PatternFill
+    import openpyxl  # type: ignore[import-untyped]
+    from openpyxl.styles import Alignment, Font, PatternFill  # type: ignore[import-untyped]
 
     wb = openpyxl.Workbook()
     ws = wb.active

--- a/src/haulpave/economics/export.py
+++ b/src/haulpave/economics/export.py
@@ -37,7 +37,7 @@ def export_comparison_to_excel(comparison: ComparisonResult, filepath: str | Pat
     header_font = Font(bold=True, size=11)
     header_fill = PatternFill(start_color="D9E1F2", end_color="D9E1F2", fill_type="solid")
     total_font = Font(bold=True, size=11)
-    money_fmt = '#,##0.00'
+    money_fmt = "#,##0.00"
 
     # -- metadata block ----------------------------------------------------
     ws["A1"] = "Method"
@@ -51,6 +51,7 @@ def export_comparison_to_excel(comparison: ComparisonResult, filepath: str | Pat
     ws["A3"] = "Generated At"
     ws["A3"].font = header_font
     from datetime import datetime, timezone
+
     ws["B3"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     # -- header row --------------------------------------------------------
@@ -72,9 +73,7 @@ def export_comparison_to_excel(comparison: ComparisonResult, filepath: str | Pat
     for i, sc in enumerate(comparison.scenarios, start=1):
         row = header_row + i
         total = (
-            sc.fuel_cost_usd_per_year
-            + sc.tire_cost_usd_per_year
-            + sc.maintenance_cost_usd_per_year
+            sc.fuel_cost_usd_per_year + sc.tire_cost_usd_per_year + sc.maintenance_cost_usd_per_year
         )
 
         ws.cell(row=row, column=1, value=sc.name)

--- a/src/haulpave/economics/export.py
+++ b/src/haulpave/economics/export.py
@@ -1,0 +1,101 @@
+"""Excel export for economics scenario comparisons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from haulpave.economics.compare import ComparisonResult
+
+__all__ = ["export_comparison_to_excel"]
+
+
+def export_comparison_to_excel(comparison: ComparisonResult, filepath: str | Path) -> str:
+    """Export scenario comparison data to an Excel workbook.
+
+    Parameters
+    ----------
+    comparison:
+        The :class:`ComparisonResult` to export.
+    filepath:
+        Destination path for the ``.xlsx`` file.
+
+    Returns
+    -------
+    str
+        The resolved absolute path of the created file.
+    """
+    import openpyxl
+    from openpyxl.styles import Alignment, Font, PatternFill
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Scenario Comparison"
+
+    # -- styling helpers --------------------------------------------------
+    header_font = Font(bold=True, size=11)
+    header_fill = PatternFill(start_color="D9E1F2", end_color="D9E1F2", fill_type="solid")
+    total_font = Font(bold=True, size=11)
+    money_fmt = '#,##0.00'
+
+    # -- metadata block ----------------------------------------------------
+    ws["A1"] = "Method"
+    ws["A1"].font = header_font
+    ws["B1"] = comparison.method
+
+    ws["A2"] = "Confidence"
+    ws["A2"].font = header_font
+    ws["B2"] = comparison.confidence
+
+    ws["A3"] = "Generated At"
+    ws["A3"].font = header_font
+    from datetime import datetime, timezone
+    ws["B3"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    # -- header row --------------------------------------------------------
+    headers = [
+        "Scenario",
+        "Fuel Cost [USD/year]",
+        "Tyre Cost [USD/year]",
+        "Maintenance Cost [USD/year]",
+        "Total Cost [USD/year]",
+    ]
+    header_row = 5
+    for col_idx, h in enumerate(headers, start=1):
+        cell = ws.cell(row=header_row, column=col_idx, value=h)
+        cell.font = header_font
+        cell.fill = header_fill
+        cell.alignment = Alignment(horizontal="center")
+
+    # -- data rows ---------------------------------------------------------
+    for i, sc in enumerate(comparison.scenarios, start=1):
+        row = header_row + i
+        total = (
+            sc.fuel_cost_usd_per_year
+            + sc.tire_cost_usd_per_year
+            + sc.maintenance_cost_usd_per_year
+        )
+
+        ws.cell(row=row, column=1, value=sc.name)
+        c2 = ws.cell(row=row, column=2, value=round(sc.fuel_cost_usd_per_year, 2))
+        c2.number_format = money_fmt
+        c3 = ws.cell(row=row, column=3, value=round(sc.tire_cost_usd_per_year, 2))
+        c3.number_format = money_fmt
+        c4 = ws.cell(row=row, column=4, value=round(sc.maintenance_cost_usd_per_year, 2))
+        c4.number_format = money_fmt
+        cell_total = ws.cell(row=row, column=5, value=round(total, 2))
+        cell_total.number_format = money_fmt
+        cell_total.font = total_font
+
+    # -- auto-width columns (approximate) -----------------------------------
+    for col_idx in range(1, len(headers) + 1):
+        max_len = len(str(ws.cell(row=header_row, column=col_idx).value))
+        for row_idx in range(header_row + 1, header_row + 1 + len(comparison.scenarios)):
+            val = ws.cell(row=row_idx, column=col_idx).value
+            if val is not None:
+                max_len = max(max_len, len(f"${val:,.2f}" if isinstance(val, float) else str(val)))
+        ws.column_dimensions[chr(64 + col_idx)].width = max_len + 3
+
+    wb.save(filepath)
+    return str(Path(filepath).resolve())

--- a/tests/test_economics/test_export.py
+++ b/tests/test_economics/test_export.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+openpyxl = pytest.importorskip("openpyxl", reason="openpyxl is required for Excel export tests")
+
 from haulpave.economics.compare import (
     ComparisonResult,
     RoadScenario,
@@ -18,16 +20,25 @@ from haulpave.economics.export import export_comparison_to_excel
 def comparison_result() -> ComparisonResult:
     scenarios = [
         RoadScenario(
-            name="Asphalt", surface="asphalt",
-            thickness_mm=100, haul_distance_km=5.0, trips_per_day=20,
+            name="Asphalt",
+            surface="asphalt",
+            thickness_mm=100,
+            haul_distance_km=5.0,
+            trips_per_day=20,
         ),
         RoadScenario(
-            name="Gravel", surface="gravel",
-            thickness_mm=600, haul_distance_km=5.0, trips_per_day=20,
+            name="Gravel",
+            surface="gravel",
+            thickness_mm=600,
+            haul_distance_km=5.0,
+            trips_per_day=20,
         ),
         RoadScenario(
-            name="Concrete", surface="concrete",
-            thickness_mm=200, haul_distance_km=5.0, trips_per_day=20,
+            name="Concrete",
+            surface="concrete",
+            thickness_mm=200,
+            haul_distance_km=5.0,
+            trips_per_day=20,
         ),
     ]
     return compare_scenarios(scenarios)
@@ -35,7 +46,9 @@ def comparison_result() -> ComparisonResult:
 
 class TestExportComparisonToExcel:
     def test_export_creates_valid_xlsx(
-        self, comparison_result: ComparisonResult, tmp_path: Path,
+        self,
+        comparison_result: ComparisonResult,
+        tmp_path: Path,
     ) -> None:
         filepath = tmp_path / "comparison.xlsx"
         result = export_comparison_to_excel(comparison_result, filepath)
@@ -43,9 +56,10 @@ class TestExportComparisonToExcel:
         assert Path(result).suffix == ".xlsx"
 
     def test_export_file_can_be_opened(
-        self, comparison_result: ComparisonResult, tmp_path: Path,
+        self,
+        comparison_result: ComparisonResult,
+        tmp_path: Path,
     ) -> None:
-        import openpyxl
         filepath = tmp_path / "comparison.xlsx"
         export_comparison_to_excel(comparison_result, filepath)
         wb = openpyxl.load_workbook(filepath)
@@ -55,9 +69,10 @@ class TestExportComparisonToExcel:
         wb.close()
 
     def test_all_scenarios_present(
-        self, comparison_result: ComparisonResult, tmp_path: Path,
+        self,
+        comparison_result: ComparisonResult,
+        tmp_path: Path,
     ) -> None:
-        import openpyxl
         filepath = tmp_path / "comparison.xlsx"
         export_comparison_to_excel(comparison_result, filepath)
         wb = openpyxl.load_workbook(filepath)
@@ -70,16 +85,19 @@ class TestExportComparisonToExcel:
         wb.close()
 
     def test_export_returns_absolute_path(
-        self, comparison_result: ComparisonResult, tmp_path: Path,
+        self,
+        comparison_result: ComparisonResult,
+        tmp_path: Path,
     ) -> None:
         filepath = tmp_path / "comparison.xlsx"
         result = export_comparison_to_excel(comparison_result, filepath)
         assert result == str(Path(filepath).resolve())
 
     def test_metadata_present(
-        self, comparison_result: ComparisonResult, tmp_path: Path,
+        self,
+        comparison_result: ComparisonResult,
+        tmp_path: Path,
     ) -> None:
-        import openpyxl
         filepath = tmp_path / "comparison.xlsx"
         export_comparison_to_excel(comparison_result, filepath)
         wb = openpyxl.load_workbook(filepath)

--- a/tests/test_economics/test_export.py
+++ b/tests/test_economics/test_export.py
@@ -8,12 +8,12 @@ import pytest
 
 openpyxl = pytest.importorskip("openpyxl", reason="openpyxl is required for Excel export tests")
 
-from haulpave.economics.compare import (
+from haulpave.economics.compare import (  # noqa: E402
     ComparisonResult,
     RoadScenario,
     compare_scenarios,
 )
-from haulpave.economics.export import export_comparison_to_excel
+from haulpave.economics.export import export_comparison_to_excel  # noqa: E402
 
 
 @pytest.fixture()

--- a/tests/test_economics/test_export.py
+++ b/tests/test_economics/test_export.py
@@ -1,0 +1,90 @@
+"""Unit tests for economics.export — Excel export."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from haulpave.economics.compare import (
+    ComparisonResult,
+    RoadScenario,
+    compare_scenarios,
+)
+from haulpave.economics.export import export_comparison_to_excel
+
+
+@pytest.fixture()
+def comparison_result() -> ComparisonResult:
+    scenarios = [
+        RoadScenario(
+            name="Asphalt", surface="asphalt",
+            thickness_mm=100, haul_distance_km=5.0, trips_per_day=20,
+        ),
+        RoadScenario(
+            name="Gravel", surface="gravel",
+            thickness_mm=600, haul_distance_km=5.0, trips_per_day=20,
+        ),
+        RoadScenario(
+            name="Concrete", surface="concrete",
+            thickness_mm=200, haul_distance_km=5.0, trips_per_day=20,
+        ),
+    ]
+    return compare_scenarios(scenarios)
+
+
+class TestExportComparisonToExcel:
+    def test_export_creates_valid_xlsx(
+        self, comparison_result: ComparisonResult, tmp_path: Path,
+    ) -> None:
+        filepath = tmp_path / "comparison.xlsx"
+        result = export_comparison_to_excel(comparison_result, filepath)
+        assert Path(result).exists()
+        assert Path(result).suffix == ".xlsx"
+
+    def test_export_file_can_be_opened(
+        self, comparison_result: ComparisonResult, tmp_path: Path,
+    ) -> None:
+        import openpyxl
+        filepath = tmp_path / "comparison.xlsx"
+        export_comparison_to_excel(comparison_result, filepath)
+        wb = openpyxl.load_workbook(filepath)
+        assert "Scenario Comparison" in wb.sheetnames
+        ws = wb["Scenario Comparison"]
+        assert ws is not None
+        wb.close()
+
+    def test_all_scenarios_present(
+        self, comparison_result: ComparisonResult, tmp_path: Path,
+    ) -> None:
+        import openpyxl
+        filepath = tmp_path / "comparison.xlsx"
+        export_comparison_to_excel(comparison_result, filepath)
+        wb = openpyxl.load_workbook(filepath)
+        ws = wb["Scenario Comparison"]
+        n = len(comparison_result.scenarios)
+        names = [ws.cell(row=r, column=1).value for r in range(6, 6 + n)]
+        assert "Asphalt" in names
+        assert "Gravel" in names
+        assert "Concrete" in names
+        wb.close()
+
+    def test_export_returns_absolute_path(
+        self, comparison_result: ComparisonResult, tmp_path: Path,
+    ) -> None:
+        filepath = tmp_path / "comparison.xlsx"
+        result = export_comparison_to_excel(comparison_result, filepath)
+        assert result == str(Path(filepath).resolve())
+
+    def test_metadata_present(
+        self, comparison_result: ComparisonResult, tmp_path: Path,
+    ) -> None:
+        import openpyxl
+        filepath = tmp_path / "comparison.xlsx"
+        export_comparison_to_excel(comparison_result, filepath)
+        wb = openpyxl.load_workbook(filepath)
+        ws = wb["Scenario Comparison"]
+        assert ws["B1"].value == comparison_result.method
+        assert ws["B2"].value == comparison_result.confidence
+        assert ws["B3"].value is not None
+        wb.close()


### PR DESCRIPTION
Closes #68

Adds Excel export for economics scenario comparisons:
- `export_comparison_to_excel()` in `src/haulpave/economics/export.py`
- Produces .xlsx with scenario cost breakdown + metadata
- openpyxl as optional dependency
- 5 unit tests for export

## Test plan
- [x] `pytest` — 289 tests pass
- [x] `ruff` — clean
- [x] `mypy` — clean