### PR TITLE
[DAS-73] API refinement: UI-friendly confidence labels, PavementResult fields, TRH14 public API, clamping feedback

### DIFF
--- a/docs/api/economics.md
+++ b/docs/api/economics.md
@@ -40,7 +40,7 @@ class EconomicsResult:
     annual_cost: float
     currency: str
     method: str = "haulpave-economics-v1"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
 ```
 
 **Source:** `src/haulpave/economics/engine.py:29`
@@ -110,7 +110,7 @@ class ScenarioComparison(BaseModel):
     tire_cost_usd_per_year: float
     fuel_cost_usd_per_year: float
     maintenance_cost_usd_per_year: float
-    confidence: ConfidenceLabel = "experimental"
+    confidence: ConfidenceLabel = "low"
 ```
 
 **Source:** `src/haulpave/economics/compare.py:59`
@@ -123,7 +123,7 @@ class ScenarioComparison(BaseModel):
 class ComparisonResult(BaseModel):
     scenarios: list[ScenarioComparison]
     method: str = "haulpave-economics-rr-v1"
-    confidence: ConfidenceLabel = "experimental"
+    confidence: ConfidenceLabel = "low"
 ```
 
 **Source:** `src/haulpave/economics/compare.py:71`

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -148,7 +148,7 @@ class DesignResult(BaseModel, frozen=True):
     pavement_structure: PavementStructure
     subgrade: SubgradeInfo
     design_coverages: float
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
     method_id: str          # e.g. "USACE-TM5-822-12"
     package_version: str    # haul pave package version
     curve_version: str | None

--- a/docs/api/pavement.md
+++ b/docs/api/pavement.md
@@ -34,7 +34,7 @@ class PavementResult:
     required_thickness_mm: float
     design_wheel_load_kn: float
     method: str = "USACE TM 5-822-12 CBR design curves + AASHTO 4th-power LEF"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
 ```
 
 **Source:** `src/haulpave/pavement/__init__.py:40`
@@ -95,7 +95,7 @@ class TRH14Result:
     total_coverages: float
     design_wheel_load_kn: float
     method: str = "TRH 14 (CSRA 1985) design catalog + USACE design-coverages"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
 ```
 
 **Source:** `src/haulpave/pavement/trh14.py:161`
@@ -140,7 +140,7 @@ class ComparisonResult:
     subgrade_cbr: float
     curve_id: str
     method: str = "USACE TM 5-822-12 CBR vs TRH 14 (CSRA 1985) comparison"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
 ```
 
 **Source:** `src/haulpave/pavement/compare.py:39`
@@ -153,4 +153,4 @@ class ComparisonResult:
 | `subgrade_cbr` | Subgrade CBR [%] used for both calculations |
 | `curve_id` | USACE CBR curve dataset identifier |
 | `method` | Human-readable method identifier |
-| `confidence` | Confidence label (inherits `benchmark_tested` from sub-engines) |
+| `confidence` | Confidence label (inherits `high` from sub-engines) |

--- a/docs/api/traffic.md
+++ b/docs/api/traffic.md
@@ -28,7 +28,7 @@ Load Equivalency Factor (LEF) method.
 class CesaResult:
     total_cesa: float
     method: str = "AASHTO 4th-power LEF (AASHTO 1993)"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
 ```
 
 **Source:** `src/haulpave/traffic/cesa.py:45`
@@ -66,7 +66,7 @@ class CoveragesResult:
     total_coverages: float
     design_wheel_load_kn: float
     method: str = "USACE TM 5-822-12 pass-count method"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"]
+    confidence: Literal["high", "medium", "low"]
 ```
 
 **Source:** `src/haulpave/traffic/coverages.py:51`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haulpave"
-version = "0.3.0"
+version = "0.4.0"
 description = "Open-source pavement structure and operating-cost analysis toolkit for mine haul roads"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/haulpave/__init__.py
+++ b/src/haulpave/__init__.py
@@ -8,4 +8,4 @@ roads and estimating operating-cost impacts.
 Docs: https://github.com/rachmad-jenss/haul-pave
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/src/haulpave/economics/compare.py
+++ b/src/haulpave/economics/compare.py
@@ -18,7 +18,7 @@ Where RR is expressed as a fraction (e.g. 0.015 for 1.5 %).
 
 Annual cost = cost_per_km × haul_distance_km × trips_per_day × working_days_per_year
 
-Confidence label: ``experimental`` — linear RR coefficients are calibrated
+Confidence label: ``low`` — linear RR coefficients are calibrated
 industry approximations; not validated against a published benchmark dossier.
 Model validates directionally: gravel > asphalt > concrete in all categories.
 """
@@ -29,7 +29,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-ConfidenceLabel = Literal["benchmark_tested", "method_implemented", "experimental"]
+ConfidenceLabel = Literal["high", "medium", "low"]
 
 __all__ = ["ComparisonResult", "RoadScenario", "ScenarioComparison", "compare_scenarios"]
 
@@ -65,7 +65,7 @@ class ScenarioComparison(BaseModel):
     tire_cost_usd_per_year: float = Field(ge=0)
     fuel_cost_usd_per_year: float = Field(ge=0)
     maintenance_cost_usd_per_year: float = Field(ge=0)
-    confidence: ConfidenceLabel = "experimental"
+    confidence: ConfidenceLabel = "low"
 
 
 class ComparisonResult(BaseModel):
@@ -75,7 +75,7 @@ class ComparisonResult(BaseModel):
 
     scenarios: list[ScenarioComparison]
     method: str = "haulpave-economics-rr-v1"
-    confidence: ConfidenceLabel = "experimental"
+    confidence: ConfidenceLabel = "low"
 
 
 def compare_scenarios(

--- a/src/haulpave/economics/engine.py
+++ b/src/haulpave/economics/engine.py
@@ -68,9 +68,7 @@ class EconomicsResult:
     annual_cost: float
     currency: str
     method: str = "haulpave-economics-v1"
-    confidence: Literal["high", "medium", "low"] = (
-        "medium"
-    )
+    confidence: Literal["high", "medium", "low"] = "medium"
 
 
 def compute_economics(

--- a/src/haulpave/economics/engine.py
+++ b/src/haulpave/economics/engine.py
@@ -13,7 +13,7 @@ Where:
 
     trip_time_hours = haul_distance_km / average_speed_kmh
 
-Confidence label: ``method_implemented`` — straightforward arithmetic,
+Confidence label: ``medium`` — straightforward arithmetic,
 not yet validated against a published benchmark dossier.
 """
 
@@ -68,8 +68,8 @@ class EconomicsResult:
     annual_cost: float
     currency: str
     method: str = "haulpave-economics-v1"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
-        "method_implemented"
+    confidence: Literal["high", "medium", "low"] = (
+        "medium"
     )
 
 

--- a/src/haulpave/models/pavement.py
+++ b/src/haulpave/models/pavement.py
@@ -43,9 +43,9 @@ class DesignResult(BaseModel):
     """Output of a pavement thickness design calculation.
 
     Confidence labels follow the project plan convention:
-    - ``benchmark_tested``: result matches a published hand-calculation benchmark
-    - ``method_implemented``: code faithfully implements the published method
-    - ``experimental``: adaptation or extension not yet benchmark-tested
+    - ``high``: result matches a published hand-calculation benchmark
+    - ``medium``: code faithfully implements the published method
+    - ``low``: adaptation or extension not yet benchmark-tested
     """
 
     model_config = ConfigDict(frozen=True)
@@ -53,7 +53,7 @@ class DesignResult(BaseModel):
     pavement_structure: PavementStructure
     subgrade: SubgradeInfo
     design_coverages: float = Field(ge=0, description="Design coverages used")
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = Field(
+    confidence: Literal["high", "medium", "low"] = Field(
         description="Confidence label per project plan §4.3"
     )
 

--- a/src/haulpave/pavement/__init__.py
+++ b/src/haulpave/pavement/__init__.py
@@ -173,7 +173,9 @@ def cbr_thickness_from_coverages(
         Required total pavement thickness [mm].
     """
     curve_data = load_curve_data(curve_id)
-    thickness, _was_clamped = interpolate_thickness(curve_data, cbr=subgrade_cbr, coverages=design_coverages)
+    thickness, _was_clamped = interpolate_thickness(
+        curve_data, cbr=subgrade_cbr, coverages=design_coverages
+    )
     return thickness
 
 
@@ -206,8 +208,8 @@ def trh14_thickness_from_coverages(
     """
     from haulpave.pavement.trh14 import (
         TRH14Result,
-        interpolate_catalog,
         cbr_to_material_class,
+        interpolate_catalog,
         load_catalog,
     )
 
@@ -226,7 +228,9 @@ def trh14_thickness_from_coverages(
 
     coverage_levels: list[int] = catalog["coverage_levels"]
     thickness_values: list[float] = thickness_table[g_class]
-    thickness, was_clamped = interpolate_catalog(thickness_values, coverage_levels, design_coverages)
+    thickness, was_clamped = interpolate_catalog(
+        thickness_values, coverage_levels, design_coverages
+    )
 
     return TRH14Result(
         material_class=g_class,

--- a/src/haulpave/pavement/__init__.py
+++ b/src/haulpave/pavement/__init__.py
@@ -18,7 +18,6 @@ References
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -121,14 +120,11 @@ def design_pavement(
     cesa_result = compute_cesa(traffic)
     cov_result = compute_coverages(traffic)
     curve_data = load_curve_data(curve_id)
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        thickness, _was_clamped = interpolate_thickness(
-            curve_data,
-            cbr=subgrade_cbr,
-            coverages=cov_result.total_coverages,
-        )
-    was_clamped = _was_clamped or any("clamped" in str(msg.message).lower() for msg in w)
+    thickness, was_clamped = interpolate_thickness(
+        curve_data,
+        cbr=subgrade_cbr,
+        coverages=cov_result.total_coverages,
+    )
     return PavementResult(
         total_cesa=cesa_result.total_cesa,
         total_coverages=cov_result.total_coverages,

--- a/src/haulpave/pavement/__init__.py
+++ b/src/haulpave/pavement/__init__.py
@@ -5,7 +5,7 @@ interpolation from digitized curve data.  Orchestrates the CESA engine
 (AASHTO 4th-power law) and the design-coverages engine (USACE pass-count
 method) then maps the result onto the CBR thickness curve.
 
-Confidence label: ``benchmark_tested`` — passes bench_03 and bench_04.
+Confidence label: ``high`` — passes bench_03 and bench_04.
 
 References
 ----------
@@ -18,6 +18,7 @@ References
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -51,8 +52,18 @@ class PavementResult:
         Total equivalent design-wheel coverages over the full design life.
     required_thickness_mm:
         Required total pavement thickness from the CBR design curve [mm].
+    total_thickness_mm:
+        Alias for ``required_thickness_mm``.  Total pavement thickness [mm].
     design_wheel_load_kn:
         Maximum single-wheel load in the fleet [kN] — the design vehicle.
+    subgrade_cbr:
+        Subgrade CBR value [%] used for the design.
+    layers:
+        Layer breakdown (empty for USACE CBR method; populated when
+        layer-specific design methods are used).
+    was_clamped:
+        True if design coverages exceeded the curve range and were clamped
+        to the nearest boundary.
     method:
         Human-readable method identifier.
     confidence:
@@ -63,10 +74,12 @@ class PavementResult:
     total_coverages: float
     required_thickness_mm: float
     design_wheel_load_kn: float
+    total_thickness_mm: float = 0.0
+    subgrade_cbr: float = 0.0
+    layers: tuple[dict[str, Any], ...] = ()
+    was_clamped: bool = False
     method: str = "USACE TM 5-822-12 CBR design curves + AASHTO 4th-power LEF"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
-        "benchmark_tested"
-    )
+    confidence: Literal["high", "medium", "low"] = "high"
 
 
 def design_pavement(
@@ -101,24 +114,29 @@ def design_pavement(
 
     Notes
     -----
-    Coverage values that exceed the curve's tabulated range are silently
-    clamped to the curve boundary by ``interpolate_thickness``.  This is the
-    correct engineering interpretation: the design is governed by the worst
-    case represented in the source chart.
+    Coverage values that exceed the curve's tabulated range are
+    clamped to the curve boundary.  ``result.was_clamped`` is ``True``
+    when clamping occurs.
     """
     cesa_result = compute_cesa(traffic)
     cov_result = compute_coverages(traffic)
     curve_data = load_curve_data(curve_id)
-    thickness = interpolate_thickness(
-        curve_data,
-        cbr=subgrade_cbr,
-        coverages=cov_result.total_coverages,
-    )
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        thickness, _was_clamped = interpolate_thickness(
+            curve_data,
+            cbr=subgrade_cbr,
+            coverages=cov_result.total_coverages,
+        )
+    was_clamped = _was_clamped or any("clamped" in str(msg.message).lower() for msg in w)
     return PavementResult(
         total_cesa=cesa_result.total_cesa,
         total_coverages=cov_result.total_coverages,
         required_thickness_mm=thickness,
+        total_thickness_mm=thickness,
         design_wheel_load_kn=cov_result.design_wheel_load_kn,
+        subgrade_cbr=subgrade_cbr,
+        was_clamped=was_clamped,
     )
 
 
@@ -155,7 +173,8 @@ def cbr_thickness_from_coverages(
         Required total pavement thickness [mm].
     """
     curve_data = load_curve_data(curve_id)
-    return interpolate_thickness(curve_data, cbr=subgrade_cbr, coverages=design_coverages)
+    thickness, _was_clamped = interpolate_thickness(curve_data, cbr=subgrade_cbr, coverages=design_coverages)
+    return thickness
 
 
 def trh14_thickness_from_coverages(
@@ -187,16 +206,16 @@ def trh14_thickness_from_coverages(
     """
     from haulpave.pavement.trh14 import (
         TRH14Result,
-        _interpolate_catalog,
-        _load_catalog,
+        interpolate_catalog,
         cbr_to_material_class,
+        load_catalog,
     )
 
     if design_coverages <= 0:
         raise ValueError(f"design_coverages must be > 0, got {design_coverages}")
 
     g_class = cbr_to_material_class(subgrade_cbr)
-    catalog = _load_catalog()
+    catalog = load_catalog()
     thickness_table: dict[str, list[float]] = catalog["thickness_mm"]
 
     if g_class not in thickness_table:
@@ -207,13 +226,14 @@ def trh14_thickness_from_coverages(
 
     coverage_levels: list[int] = catalog["coverage_levels"]
     thickness_values: list[float] = thickness_table[g_class]
-    thickness = _interpolate_catalog(thickness_values, coverage_levels, design_coverages)
+    thickness, was_clamped = interpolate_catalog(thickness_values, coverage_levels, design_coverages)
 
     return TRH14Result(
         material_class=g_class,
         total_thickness_mm=thickness,
         total_coverages=design_coverages,
         design_wheel_load_kn=0.0,  # unknown when using pre-computed coverages
+        was_clamped=was_clamped,
     )
 
 

--- a/src/haulpave/pavement/compare.py
+++ b/src/haulpave/pavement/compare.py
@@ -67,9 +67,7 @@ class ComparisonResult:
     subgrade_cbr: float
     curve_id: str
     method: str = "USACE TM 5-822-12 CBR vs TRH 14 (CSRA 1985) comparison"
-    confidence: Literal["high", "medium", "low"] = (
-        "high"
-    )
+    confidence: Literal["high", "medium", "low"] = "high"
 
 
 def compare_methods(

--- a/src/haulpave/pavement/compare.py
+++ b/src/haulpave/pavement/compare.py
@@ -9,7 +9,7 @@ Pipeline
 2. TRH 14 path (``compute_trh14``) — USACE coverages + TRH 14 catalog.
 3. delta_mm = TRH 14 thickness − USACE thickness.
 
-Confidence label: ``benchmark_tested`` — both sub-engines are benchmark_tested;
+Confidence label: ``high`` — both sub-engines are ``high`` confidence;
 comparison arithmetic is verified in tests against known sub-results.
 
 References
@@ -58,8 +58,7 @@ class ComparisonResult:
     method:
         Human-readable method identifier.
     confidence:
-        Confidence label.  Inherits from sub-engines: both are
-        ``benchmark_tested``.
+        Confidence label.  Inherits from sub-engines: both are ``high``.
     """
 
     usace: PavementResult
@@ -68,8 +67,8 @@ class ComparisonResult:
     subgrade_cbr: float
     curve_id: str
     method: str = "USACE TM 5-822-12 CBR vs TRH 14 (CSRA 1985) comparison"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
-        "benchmark_tested"
+    confidence: Literal["high", "medium", "low"] = (
+        "high"
     )
 
 

--- a/src/haulpave/pavement/trh14.py
+++ b/src/haulpave/pavement/trh14.py
@@ -201,9 +201,7 @@ class TRH14Result:
     design_wheel_load_kn: float
     was_clamped: bool = False
     method: str = "TRH 14 (CSRA 1985) design catalog + USACE design-coverages"
-    confidence: Literal["high", "medium", "low"] = (
-        "high"
-    )
+    confidence: Literal["high", "medium", "low"] = "high"
 
 
 def compute_trh14(traffic: TrafficInput, subgrade_cbr: float) -> TRH14Result:

--- a/src/haulpave/pavement/trh14.py
+++ b/src/haulpave/pavement/trh14.py
@@ -9,7 +9,7 @@ on the design-coverages axis.
 Design traffic is computed via the USACE TM 5-822-12 design-coverages method
 (same ``compute_coverages`` engine used by the USACE CBR path).
 
-Confidence label: ``benchmark_tested`` — passes bench_05.
+Confidence label: ``high`` — passes bench_05.
 
 References
 ----------
@@ -35,13 +35,21 @@ from typing import Any, Literal
 from haulpave.models.traffic import TrafficInput
 from haulpave.traffic.coverages import compute_coverages
 
-__all__ = ["TRH14Result", "cbr_to_material_class", "compute_trh14"]
+__all__ = [
+    "TRH14Result",
+    "cbr_to_material_class",
+    "compute_trh14",
+    "CATALOG_PATH",
+    "G_CLASS_BOUNDS",
+    "interpolate_catalog",
+    "load_catalog",
+]
 
-_CATALOG_PATH = Path(__file__).parent.parent / "design" / "curves" / "trh14_catalog_v1.json"
+CATALOG_PATH = Path(__file__).parent.parent / "design" / "curves" / "trh14_catalog_v1.json"
 
 # G-class lower-CBR boundaries in descending order (strongest first).
 # Boundary is inclusive on the lower end: CBR=7 → G5 (not G6).
-_G_CLASS_BOUNDS: list[tuple[str, float]] = [
+G_CLASS_BOUNDS: list[tuple[str, float]] = [
     ("G1", 80.0),
     ("G2", 45.0),
     ("G3", 25.0),
@@ -79,27 +87,27 @@ def cbr_to_material_class(cbr: float) -> str:
     """
     if cbr < 0:
         raise ValueError(f"CBR must be >= 0, got {cbr}")
-    for g_class, min_cbr in _G_CLASS_BOUNDS:
+    for g_class, min_cbr in G_CLASS_BOUNDS:
         if cbr >= min_cbr:
             return g_class
     return "G9"  # pragma: no cover — G9 bound=0.0 catches all remaining values
 
 
 @lru_cache(maxsize=1)
-def _load_catalog() -> dict[str, Any]:
+def load_catalog() -> dict[str, Any]:
     """Load TRH 14 design catalog JSON (cached per process)."""
-    with _CATALOG_PATH.open(encoding="utf-8") as fh:
+    with CATALOG_PATH.open(encoding="utf-8") as fh:
         return json.load(fh)  # type: ignore[no-any-return]
 
 
-def _interpolate_catalog(
+def interpolate_catalog(
     thickness_values: list[float],
     coverage_levels: list[int],
     coverages: float,
-) -> float:
+) -> tuple[float, bool]:
     """Log-linear interpolation of thickness at a given coverage level.
 
-    Coverage values outside the catalog range are silently clamped to the
+    Coverage values outside the catalog range are clamped to the
     nearest boundary — consistent with the USACE interpolation convention.
 
     Parameters
@@ -113,8 +121,8 @@ def _interpolate_catalog(
 
     Returns
     -------
-    float
-        Interpolated total pavement thickness [mm].
+    tuple[float, bool]
+        Interpolated total pavement thickness [mm] and whether clamping occurred.
 
     Raises
     ------
@@ -128,6 +136,7 @@ def _interpolate_catalog(
             "Catalog shape mismatch: len(thickness_values) must equal len(coverage_levels)"
         )
 
+    was_clamped = False
     if coverages < coverage_levels[0]:
         warnings.warn(
             f"TRH 14: design coverages ({coverages:.0f}) below catalog minimum "
@@ -135,6 +144,7 @@ def _interpolate_catalog(
             UserWarning,
             stacklevel=2,
         )
+        was_clamped = True
     elif coverages > coverage_levels[-1]:
         warnings.warn(
             f"TRH 14: design coverages ({coverages:.0f}) exceed catalog maximum "
@@ -142,6 +152,7 @@ def _interpolate_catalog(
             UserWarning,
             stacklevel=2,
         )
+        was_clamped = True
     cov_clamped = max(float(coverage_levels[0]), min(float(coverage_levels[-1]), coverages))
     log_cov = math.log10(cov_clamped)
     log_levels = [math.log10(float(c)) for c in coverage_levels]
@@ -151,10 +162,10 @@ def _interpolate_catalog(
         if log_levels[i] <= log_cov <= log_levels[i + 1]:
             span = log_levels[i + 1] - log_levels[i]
             frac = (log_cov - log_levels[i]) / span if span > 0 else 0.0
-            return thickness_values[i] + frac * (thickness_values[i + 1] - thickness_values[i])
+            return thickness_values[i] + frac * (thickness_values[i + 1] - thickness_values[i]), was_clamped
 
     # Clamped value equals the upper boundary exactly
-    return float(thickness_values[-1])  # pragma: no cover
+    return float(thickness_values[-1]), was_clamped  # pragma: no cover
 
 
 @dataclass(frozen=True)
@@ -172,6 +183,9 @@ class TRH14Result:
         (USACE TM 5-822-12 method).
     design_wheel_load_kn:
         Maximum single-wheel load in the fleet [kN] — the design vehicle.
+    was_clamped:
+        True if design coverages exceeded the catalog range and were clamped
+        to the nearest boundary.
     method:
         Human-readable method identifier.
     confidence:
@@ -182,9 +196,10 @@ class TRH14Result:
     total_thickness_mm: float
     total_coverages: float
     design_wheel_load_kn: float
+    was_clamped: bool = False
     method: str = "TRH 14 (CSRA 1985) design catalog + USACE design-coverages"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
-        "benchmark_tested"
+    confidence: Literal["high", "medium", "low"] = (
+        "high"
     )
 
 
@@ -218,7 +233,7 @@ def compute_trh14(traffic: TrafficInput, subgrade_cbr: float) -> TRH14Result:
     cov_result = compute_coverages(traffic)
     g_class = cbr_to_material_class(subgrade_cbr)
 
-    catalog = _load_catalog()
+    catalog = load_catalog()
     thickness_table: dict[str, list[float]] = catalog["thickness_mm"]
 
     if g_class not in thickness_table:
@@ -231,11 +246,14 @@ def compute_trh14(traffic: TrafficInput, subgrade_cbr: float) -> TRH14Result:
     coverage_levels: list[int] = catalog["coverage_levels"]
     thickness_values: list[float] = thickness_table[g_class]
 
-    thickness = _interpolate_catalog(thickness_values, coverage_levels, cov_result.total_coverages)
+    thickness, was_clamped = interpolate_catalog(
+        thickness_values, coverage_levels, cov_result.total_coverages
+    )
 
     return TRH14Result(
         material_class=g_class,
         total_thickness_mm=thickness,
         total_coverages=cov_result.total_coverages,
         design_wheel_load_kn=cov_result.design_wheel_load_kn,
+        was_clamped=was_clamped,
     )

--- a/src/haulpave/pavement/trh14.py
+++ b/src/haulpave/pavement/trh14.py
@@ -162,7 +162,10 @@ def interpolate_catalog(
         if log_levels[i] <= log_cov <= log_levels[i + 1]:
             span = log_levels[i + 1] - log_levels[i]
             frac = (log_cov - log_levels[i]) / span if span > 0 else 0.0
-            return thickness_values[i] + frac * (thickness_values[i + 1] - thickness_values[i]), was_clamped
+            return (
+                thickness_values[i] + frac * (thickness_values[i + 1] - thickness_values[i]),
+                was_clamped,
+            )
 
     # Clamped value equals the upper boundary exactly
     return float(thickness_values[-1]), was_clamped  # pragma: no cover

--- a/src/haulpave/traffic/cesa.py
+++ b/src/haulpave/traffic/cesa.py
@@ -24,7 +24,7 @@ CESA per vehicle per direction
 
 Total CESA = sum over all FleetUnits.
 
-Confidence label: ``benchmark_tested`` — matches published hand-calc within ±1 %.
+Confidence label: ``high`` — matches published hand-calc within ±1 %.
 """
 
 from __future__ import annotations
@@ -57,8 +57,8 @@ class CesaResult:
 
     total_cesa: float
     method: str = "AASHTO 4th-power LEF (AASHTO 1993)"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
-        "benchmark_tested"
+    confidence: Literal["high", "medium", "low"] = (
+        "high"
     )
 
 

--- a/src/haulpave/traffic/cesa.py
+++ b/src/haulpave/traffic/cesa.py
@@ -57,9 +57,7 @@ class CesaResult:
 
     total_cesa: float
     method: str = "AASHTO 4th-power LEF (AASHTO 1993)"
-    confidence: Literal["high", "medium", "low"] = (
-        "high"
-    )
+    confidence: Literal["high", "medium", "low"] = "high"
 
 
 def _lef_for_axle_group(group: AxleGroup) -> float:

--- a/src/haulpave/traffic/coverages.py
+++ b/src/haulpave/traffic/coverages.py
@@ -66,9 +66,7 @@ class CoveragesResult:
     total_coverages: float
     design_wheel_load_kn: float
     method: str = "USACE TM 5-822-12 pass-count method"
-    confidence: Literal["high", "medium", "low"] = (
-        "high"
-    )
+    confidence: Literal["high", "medium", "low"] = "high"
 
 
 def _wheel_load_kn(group: AxleGroup) -> float:

--- a/src/haulpave/traffic/coverages.py
+++ b/src/haulpave/traffic/coverages.py
@@ -33,7 +33,7 @@ Total design coverages
 -----------------------
   total_coverages = Σ_vehicle_types(equiv_passes/day) × working_days × design_life
 
-Confidence label: ``benchmark_tested`` — matches published hand-calc within ±2 %.
+Confidence label: ``high`` — matches published hand-calc within ±2 %.
 """
 
 from __future__ import annotations
@@ -66,8 +66,8 @@ class CoveragesResult:
     total_coverages: float
     design_wheel_load_kn: float
     method: str = "USACE TM 5-822-12 pass-count method"
-    confidence: Literal["benchmark_tested", "method_implemented", "experimental"] = (
-        "benchmark_tested"
+    confidence: Literal["high", "medium", "low"] = (
+        "high"
     )
 
 

--- a/src/haulpave/utils/interpolation.py
+++ b/src/haulpave/utils/interpolation.py
@@ -59,7 +59,7 @@ def interpolate_thickness(
     curve_data: dict[str, Any],
     cbr: float,
     coverages: float,
-) -> float:
+) -> tuple[float, bool]:
     """Interpolate required pavement thickness for given CBR and design coverages.
 
     Uses 2-step PCHIP interpolation:
@@ -76,7 +76,8 @@ def interpolate_thickness(
             the curve's coverage range are clamped to the boundary.
 
     Returns:
-        Required total pavement thickness [mm].
+        Tuple of (required total pavement thickness [mm], was_clamped).
+        ``was_clamped`` is True when coverages were outside the curve range.
 
     Raises:
         ValueError: If CBR is outside the supported range, coverages <= 0,
@@ -92,7 +93,7 @@ def interpolate_thickness(
     if coverages <= 0:
         raise ValueError(f"coverages must be > 0, got {coverages}")
 
-    # Clamp coverages to range with warning
+    was_clamped = False
     if coverages < coverage_levels[0]:
         warnings.warn(
             f"USACE CBR: design coverages ({coverages:.0f}) below curve minimum "
@@ -100,6 +101,7 @@ def interpolate_thickness(
             UserWarning,
             stacklevel=2,
         )
+        was_clamped = True
     elif coverages > coverage_levels[-1]:
         warnings.warn(
             f"USACE CBR: design coverages ({coverages:.0f}) exceed curve maximum "
@@ -107,6 +109,7 @@ def interpolate_thickness(
             UserWarning,
             stacklevel=2,
         )
+        was_clamped = True
     log_cov = np.log10(np.clip(coverages, coverage_levels[0], coverage_levels[-1]))
     log_cov_levels = np.log10(coverage_levels)
 
@@ -119,4 +122,4 @@ def interpolate_thickness(
 
     # Interpolate across coverage levels (log scale)
     cov_pchip = PchipInterpolator(log_cov_levels, thicknesses_at_coverages)
-    return float(cov_pchip(log_cov))
+    return float(cov_pchip(log_cov)), was_clamped

--- a/tests/benchmarks/bench_03_cbr_usace_example.py
+++ b/tests/benchmarks/bench_03_cbr_usace_example.py
@@ -117,7 +117,7 @@ def test_cbr_thickness_interpolation(case_id: str, cbr: float, coverages: float)
     the hardcoded expected values in bench_03_expected.json.
     """
     expected = _CASES[case_id]["expected_thickness_mm"]
-    computed = interpolate_thickness(_CURVE_DATA, cbr, coverages)
+    computed, _was_clamped = interpolate_thickness(_CURVE_DATA, cbr, coverages)
     _assert_close(computed, expected, f"{case_id} (CBR={cbr}, cov={coverages})")
 
 
@@ -130,8 +130,8 @@ class TestCBRThicknessMonotonicity:
 
     def test_thickness_increases_with_coverages(self) -> None:
         """At constant CBR, more coverages must require more thickness."""
-        t_low = interpolate_thickness(_CURVE_DATA, cbr=5, coverages=100)
-        t_high = interpolate_thickness(_CURVE_DATA, cbr=5, coverages=10000)
+        t_low, _ = interpolate_thickness(_CURVE_DATA, cbr=5, coverages=100)
+        t_high, _ = interpolate_thickness(_CURVE_DATA, cbr=5, coverages=10000)
         assert t_high > t_low, (
             f"Expected more thickness at higher coverages: "
             f"cov=100 → {t_low:.1f} mm, cov=10000 → {t_high:.1f} mm"
@@ -139,8 +139,8 @@ class TestCBRThicknessMonotonicity:
 
     def test_thickness_decreases_with_cbr(self) -> None:
         """At constant coverages, stronger subgrade (higher CBR) requires less thickness."""
-        t_weak = interpolate_thickness(_CURVE_DATA, cbr=3, coverages=1000)
-        t_strong = interpolate_thickness(_CURVE_DATA, cbr=15, coverages=1000)
+        t_weak, _ = interpolate_thickness(_CURVE_DATA, cbr=3, coverages=1000)
+        t_strong, _ = interpolate_thickness(_CURVE_DATA, cbr=15, coverages=1000)
         assert t_strong < t_weak, (
             f"Expected less thickness for stronger subgrade: "
             f"CBR=3 → {t_weak:.1f} mm, CBR=15 → {t_strong:.1f} mm"
@@ -148,8 +148,8 @@ class TestCBRThicknessMonotonicity:
 
     def test_case_a_thicker_than_case_c(self) -> None:
         """Case A (soft subgrade, moderate traffic) must exceed Case C (firm, high traffic)."""
-        t_a = interpolate_thickness(_CURVE_DATA, cbr=3, coverages=1000)
-        t_c = interpolate_thickness(_CURVE_DATA, cbr=15, coverages=50000)
+        t_a, _ = interpolate_thickness(_CURVE_DATA, cbr=3, coverages=1000)
+        t_c, _ = interpolate_thickness(_CURVE_DATA, cbr=15, coverages=50000)
         assert t_a > t_c, (
             f"Case A (CBR=3, cov=1000) thickness {t_a:.1f} mm should exceed "
             f"Case C (CBR=15, cov=50000) {t_c:.1f} mm"

--- a/tests/test_economics/test_engine.py
+++ b/tests/test_economics/test_engine.py
@@ -76,9 +76,9 @@ class TestComputeEconomics:
         result = compute_economics(scenario)
         assert result.scenario_id == "test-01"
 
-    def test_confidence_is_method_implemented(self, scenario: CostScenario) -> None:
+    def test_confidence_is_medium(self, scenario: CostScenario) -> None:
         result = compute_economics(scenario)
-        assert result.confidence == "method_implemented"
+        assert result.confidence == "medium"
 
     def test_result_is_frozen(self, scenario: CostScenario) -> None:
         result = compute_economics(scenario)

--- a/tests/test_models/test_pavement.py
+++ b/tests/test_models/test_pavement.py
@@ -58,11 +58,11 @@ class TestDesignResult:
             pavement_structure=structure,
             subgrade=subgrade,
             design_coverages=1500.0,
-            confidence="benchmark_tested",
+            confidence="high",
             method_id="USACE-TM5-822-12",
             package_version="0.0.1",
         )
-        assert dr.confidence == "benchmark_tested"
+        assert dr.confidence == "high"
         assert dr.curve_version is None
         assert dr.input_hash is None
 
@@ -82,7 +82,7 @@ class TestDesignResult:
     def test_all_confidence_literals(
         self, structure: PavementStructure, subgrade: SubgradeInfo
     ) -> None:
-        for label in ("benchmark_tested", "method_implemented", "experimental"):
+        for label in ("high", "medium", "low"):
             dr = DesignResult(
                 pavement_structure=structure,
                 subgrade=subgrade,

--- a/tests/test_pavement/test_compare.py
+++ b/tests/test_pavement/test_compare.py
@@ -63,7 +63,7 @@ class TestCompareMethodsReturnType:
         assert result.curve_id == "usace_cbr_v1"
         assert "USACE" in result.method
         assert "TRH 14" in result.method
-        assert result.confidence == "benchmark_tested"
+        assert result.confidence == "high"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pavement/test_design.py
+++ b/tests/test_pavement/test_design.py
@@ -96,14 +96,14 @@ class TestPavementResult:
         assert "AASHTO" in result.method
 
     def test_result_default_confidence(self) -> None:
-        """Default confidence must be 'benchmark_tested'."""
+        """Default confidence must be 'high'."""
         result = PavementResult(
             total_cesa=1.0,
             total_coverages=1.0,
             required_thickness_mm=300.0,
             design_wheel_load_kn=80.0,
         )
-        assert result.confidence == "benchmark_tested"
+        assert result.confidence == "high"
 
     def test_result_fields_accessible(self) -> None:
         """All fields are directly accessible on the result."""

--- a/tests/test_pavement/test_design.py
+++ b/tests/test_pavement/test_design.py
@@ -112,11 +112,41 @@ class TestPavementResult:
             total_coverages=530_357.24,
             required_thickness_mm=564.49,
             design_wheel_load_kn=112.5,
+            total_thickness_mm=564.49,
+            subgrade_cbr=7.0,
         )
         assert result.total_cesa == pytest.approx(508_634_682.58, rel=1e-6)
         assert result.total_coverages == pytest.approx(530_357.24, rel=1e-6)
         assert result.required_thickness_mm == pytest.approx(564.49, rel=1e-6)
         assert result.design_wheel_load_kn == pytest.approx(112.5, rel=1e-6)
+        assert result.total_thickness_mm == pytest.approx(564.49, rel=1e-6)
+        assert result.subgrade_cbr == pytest.approx(7.0)
+        assert result.layers == ()
+        assert not result.was_clamped
+
+    def test_total_thickness_mm_matches_required(self) -> None:
+        """total_thickness_mm must equal required_thickness_mm."""
+        result = PavementResult(
+            total_cesa=1.0,
+            total_coverages=1.0,
+            required_thickness_mm=300.0,
+            design_wheel_load_kn=80.0,
+            total_thickness_mm=300.0,
+        )
+        assert result.total_thickness_mm == result.required_thickness_mm
+
+    def test_was_clamped_flag_from_design(self, fleet_b_traffic: TrafficInput) -> None:
+        """Fleet B coverages exceed curve max — was_clamped must be True."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = design_pavement(
+                traffic=fleet_b_traffic,
+                subgrade_cbr=7.0,
+                curve_id="usace_cbr_v1",
+            )
+        assert result.was_clamped
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pavement/test_trh14.py
+++ b/tests/test_pavement/test_trh14.py
@@ -15,9 +15,9 @@ from haulpave.models.traffic import FleetUnit, TrafficInput
 from haulpave.models.vehicle import MiningVehicle
 from haulpave.pavement.trh14 import (
     TRH14Result,
-    _interpolate_catalog,
     cbr_to_material_class,
     compute_trh14,
+    interpolate_catalog,
 )
 
 from ..conftest import make_single_axle, make_tandem_axle
@@ -97,7 +97,7 @@ class TestComputeTrh14ReturnType:
         assert result.total_thickness_mm > 0
         assert result.design_wheel_load_kn > 0
         assert "TRH 14" in result.method
-        assert result.confidence == "benchmark_tested"
+        assert result.confidence == "high"
 
     def test_coverages_match_fleet_d(self, fleet_d: TrafficInput) -> None:
         """Fleet D produces 67,500 coverages (hand-calc, bench_05)."""
@@ -208,22 +208,22 @@ class TestInterpolateCatalog:
     def test_empty_coverage_levels_raises(self) -> None:
         """Empty coverage_levels raises ValueError."""
         with pytest.raises(ValueError, match="must be non-empty"):
-            _interpolate_catalog([150.0], [], 1000.0)
+            interpolate_catalog([150.0], [], 1000.0)
 
     def test_empty_thickness_values_raises(self) -> None:
         """Empty thickness_values raises ValueError."""
         with pytest.raises(ValueError, match="must be non-empty"):
-            _interpolate_catalog([], [100], 1000.0)
+            interpolate_catalog([], [100], 1000.0)
 
     def test_shape_mismatch_raises(self) -> None:
         """Length mismatch raises ValueError."""
         with pytest.raises(ValueError, match="Catalog shape mismatch"):
-            _interpolate_catalog([150.0, 300.0], [100, 1000, 10000], 1000.0)
+            interpolate_catalog([150.0, 300.0], [100, 1000, 10000], 1000.0)
 
     def test_shape_mismatch_with_single_value(self) -> None:
         """Single thickness value with multi-element coverage also raises."""
         with pytest.raises(ValueError, match="Catalog shape mismatch"):
-            _interpolate_catalog([150.0], [100, 1000, 10000], 1000.0)
+            interpolate_catalog([150.0], [100, 1000, 10000], 1000.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pavement/test_trh14.py
+++ b/tests/test_pavement/test_trh14.py
@@ -179,6 +179,7 @@ class TestComputeTrh14CoverageClamping:
             result = compute_trh14(traffic_low, subgrade_cbr=10.0)
         assert result.total_coverages < 100  # confirms input is below catalog min
         assert result.total_thickness_mm == pytest.approx(150.0, abs=1e-6)  # G5 @ min knot
+        assert result.was_clamped  # clamping flag must be True
 
     def test_very_high_coverages_clamped(self) -> None:
         """Extremely heavy traffic → coverages above catalog maximum, clamped downward."""
@@ -197,6 +198,7 @@ class TestComputeTrh14CoverageClamping:
             result = compute_trh14(traffic_heavy, subgrade_cbr=10.0)
         assert result.total_coverages > 1_000_000  # confirms input is above catalog max
         assert result.total_thickness_mm == pytest.approx(600.0, abs=1e-6)  # G5 @ max knot
+        assert result.was_clamped  # clamping flag must be True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_traffic/test_cesa.py
+++ b/tests/test_traffic/test_cesa.py
@@ -97,10 +97,10 @@ class TestCesaResultMetadata:
         result = compute_cesa(make_traffic(vehicle))
         assert "4th" in result.method or "4th" in result.method.lower()
 
-    def test_confidence_is_benchmark_tested(self) -> None:
+    def test_confidence_is_high(self) -> None:
         vehicle = make_vehicle("V", [make_single_axle(80.0)])
         result = compute_cesa(make_traffic(vehicle))
-        assert result.confidence == "benchmark_tested"
+        assert result.confidence == "high"
 
     def test_result_is_immutable(self) -> None:
         """CesaResult is a frozen dataclass — mutation must raise."""

--- a/tests/test_traffic/test_coverages.py
+++ b/tests/test_traffic/test_coverages.py
@@ -71,7 +71,7 @@ class TestCoveragesResult:
 
     def test_default_confidence(self) -> None:
         result = CoveragesResult(total_coverages=1000.0, design_wheel_load_kn=77.5)
-        assert result.confidence == "benchmark_tested"
+        assert result.confidence == "high"
 
     def test_fields_accessible(self) -> None:
         result = CoveragesResult(total_coverages=12345.6, design_wheel_load_kn=112.5)
@@ -381,11 +381,11 @@ class TestComputeCoverages:
             f"Expected ratio {expected_ratio:.6f}, got {actual_ratio:.6f}"
         )
 
-    def test_confidence_is_benchmark_tested(self) -> None:
+    def test_confidence_is_high(self) -> None:
         vehicle = _make_vehicle("V1", 30.0, [make_single_axle(100.0)])
         traffic = _make_traffic([FleetUnit(vehicle=vehicle, trips_per_day=10)])
         result = compute_coverages(traffic)
-        assert result.confidence == "benchmark_tested"
+        assert result.confidence == "high"
 
     def test_positive_coverages(self) -> None:
         vehicle = _make_vehicle("V1", 30.0, [make_single_axle(100.0)])

--- a/tests/test_utils/test_interpolation.py
+++ b/tests/test_utils/test_interpolation.py
@@ -176,7 +176,9 @@ class TestInterpolateThickness:
     def test_coverages_above_max_clamps_to_max_level(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """Coverages above curve maximum are clamped to maximum coverage level (100000)."""
         with pytest.warns(UserWarning, match="exceed curve maximum"):
-            result_clamped, was_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1_000_000)
+            result_clamped, was_clamped = interpolate_thickness(
+                curve_data, cbr=10, coverages=1_000_000
+            )
         result_max, _ = interpolate_thickness(curve_data, cbr=10, coverages=100_000)
         assert was_clamped, "Expected was_clamped=True when coverages exceed maximum"
         assert result_clamped == result_max, (

--- a/tests/test_utils/test_interpolation.py
+++ b/tests/test_utils/test_interpolation.py
@@ -95,19 +95,19 @@ class TestLoadCurveData:
 class TestInterpolateThickness:
     def test_cbr10_coverages1000_approx_408mm(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """Benchmark: CBR=10, coverages=1000 -> ~408 mm (+-5 mm)."""
-        result = interpolate_thickness(curve_data, cbr=10, coverages=1000)
+        result, _ = interpolate_thickness(curve_data, cbr=10, coverages=1000)
         assert abs(result - 408.0) <= 5.0, f"Expected ~408 mm, got {result:.1f} mm"
 
     def test_cbr5_coverages100_approx_462mm(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """Benchmark: CBR=5, coverages=100 -> ~462 mm (+-5 mm)."""
-        result = interpolate_thickness(curve_data, cbr=5, coverages=100)
+        result, _ = interpolate_thickness(curve_data, cbr=5, coverages=100)
         assert abs(result - 462.0) <= 5.0, f"Expected ~462 mm, got {result:.1f} mm"
 
     def test_monotonicity_higher_cbr_lower_thickness(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """Higher CBR -> lower required thickness (same coverages)."""
         cbr_values = [5, 10, 20, 30, 50]
         thicknesses = [
-            interpolate_thickness(curve_data, cbr=cbr, coverages=1000) for cbr in cbr_values
+            interpolate_thickness(curve_data, cbr=cbr, coverages=1000)[0] for cbr in cbr_values
         ]
         for i in range(len(thicknesses) - 1):
             assert thicknesses[i] > thicknesses[i + 1], (
@@ -123,7 +123,7 @@ class TestInterpolateThickness:
         """Higher coverages -> higher required thickness (same CBR)."""
         coverage_values = [100, 1000, 10000, 100000]
         thicknesses = [
-            interpolate_thickness(curve_data, cbr=10, coverages=cov) for cov in coverage_values
+            interpolate_thickness(curve_data, cbr=10, coverages=cov)[0] for cov in coverage_values
         ]
         for i in range(len(thicknesses) - 1):
             assert thicknesses[i] < thicknesses[i + 1], (
@@ -144,12 +144,12 @@ class TestInterpolateThickness:
 
     def test_boundary_cbr_min(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """CBR=2 (minimum boundary) works without error."""
-        result = interpolate_thickness(curve_data, cbr=2, coverages=1000)
+        result, _ = interpolate_thickness(curve_data, cbr=2, coverages=1000)
         assert result > 0
 
     def test_boundary_cbr_max(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """CBR=100 (maximum boundary) works without error."""
-        result = interpolate_thickness(curve_data, cbr=100, coverages=1000)
+        result, _ = interpolate_thickness(curve_data, cbr=100, coverages=1000)
         assert result > 0
 
     def test_raises_value_error_zero_coverages(self, curve_data: dict) -> None:  # type: ignore[type-arg]
@@ -165,8 +165,9 @@ class TestInterpolateThickness:
     def test_coverages_below_min_clamps_to_min_level(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """Coverages below curve minimum are clamped to minimum coverage level (10)."""
         with pytest.warns(UserWarning, match="below curve minimum"):
-            result_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1)
-        result_min = interpolate_thickness(curve_data, cbr=10, coverages=10)
+            result_clamped, was_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1)
+        result_min, _ = interpolate_thickness(curve_data, cbr=10, coverages=10)
+        assert was_clamped, "Expected was_clamped=True when coverages below minimum"
         assert result_clamped == result_min, (
             f"Expected coverages=1 to clamp to coverages=10: "
             f"got {result_clamped:.1f} vs {result_min:.1f} mm"
@@ -175,8 +176,9 @@ class TestInterpolateThickness:
     def test_coverages_above_max_clamps_to_max_level(self, curve_data: dict) -> None:  # type: ignore[type-arg]
         """Coverages above curve maximum are clamped to maximum coverage level (100000)."""
         with pytest.warns(UserWarning, match="exceed curve maximum"):
-            result_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1_000_000)
-        result_max = interpolate_thickness(curve_data, cbr=10, coverages=100_000)
+            result_clamped, was_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1_000_000)
+        result_max, _ = interpolate_thickness(curve_data, cbr=10, coverages=100_000)
+        assert was_clamped, "Expected was_clamped=True when coverages exceed maximum"
         assert result_clamped == result_max, (
             f"Expected coverages=1_000_000 to clamp to coverages=100_000: "
             f"got {result_clamped:.1f} vs {result_max:.1f} mm"
@@ -189,3 +191,20 @@ class TestInterpolateThickness:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             interpolate_thickness(curve_data, cbr=10, coverages=1000)
+
+    def test_was_clamped_false_in_range(self, curve_data: dict) -> None:  # type: ignore[type-arg]
+        """was_clamped is False when coverages are within curve range."""
+        _result, was_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1000)
+        assert not was_clamped
+
+    def test_was_clamped_true_below_min(self, curve_data: dict) -> None:  # type: ignore[type-arg]
+        """was_clamped is True when coverages are below curve minimum."""
+        with pytest.warns(UserWarning):
+            _result, was_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1)
+        assert was_clamped
+
+    def test_was_clamped_true_above_max(self, curve_data: dict) -> None:  # type: ignore[type-arg]
+        """was_clamped is True when coverages exceed curve maximum."""
+        with pytest.warns(UserWarning):
+            _result, was_clamped = interpolate_thickness(curve_data, cbr=10, coverages=1_000_000)
+        assert was_clamped


### PR DESCRIPTION
Closes #73

## Summary

Four API refinements to haul-pave surfaced by integration testing:

### 1. Confidence labels → UI-friendly
`Literal["benchmark_tested", "method_implemented", "experimental"]` → `Literal["high", "medium", "low"]`

Updated across all 9 result classes: `PavementResult`, `ComparisonResult`, `TRH14Result`, `CesaResult`, `CoveragesResult`, `EconomicsResult`, `DesignResult`, `ScenarioComparison`, `ComparisonResult` (economics).

### 2. PavementResult restructure
Added fields: `total_thickness_mm`, `subgrade_cbr`, `layers`, `was_clamped`
- `total_thickness_mm` = alias for `required_thickness_mm` (both set by `design_pavement`)
- `subgrade_cbr` propagated from input
- `layers` reserved for future layer-specific methods

### 3. TRH14 public API
Unprivated functions/constants that are mature and needed by consumers:
- `_load_catalog()` → `load_catalog()`
- `_interpolate_catalog()` → `interpolate_catalog()`
- `_CATALOG_PATH` → `CATALOG_PATH`
- `_G_CLASS_BOUNDS` → `G_CLASS_BOUNDS`

All added to `__all__`.

### 4. Clamping feedback
- `interpolate_thickness()` returns `tuple[float, bool]` — `(thickness, was_clamped)`
- `interpolate_catalog()` (TRH14) returns same tuple
- `PavementResult.was_clamped` and `TRH14Result.was_clamped` set by orchestration functions

## Test Plan
- [x] `pytest tests/` — 294 tests pass (including benchmarks)
- [x] All old confidence string literals removed from source; HaulSegment "experimental" warning preserved (user-facing text, not a confidence label)
- [x] `was_clamped` flag tested at both low-level (`interpolate_thickness`) and result-level (`PavementResult`, `TRH14Result`)
- [x] `total_thickness_mm` alias verified in dataclass test
- [x] Bridge adapters (`cbr_thickness_from_coverages`, `trh14_thickness_from_coverages`) return expected types
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — all files formatted

## Version
`0.3.0` → `0.4.0` (breaking API change — confidence values renamed, `interpolate_thickness` return type changed)