### PR TITLE
[DAS-79] Missing input_hash in DesignSummary report metadata

### DIFF
--- a/src/haulpave/reporting/__init__.py
+++ b/src/haulpave/reporting/__init__.py
@@ -1,5 +1,5 @@
 """Reporting module — versioned design summaries, text reports, Excel export."""
 
-from haulpave.reporting.summary import DesignSummary, build_design_summary
+from haulpave.reporting.summary import DesignSummary, build_design_summary, compute_input_hash
 
-__all__ = ["DesignSummary", "build_design_summary"]
+__all__ = ["DesignSummary", "build_design_summary", "compute_input_hash"]

--- a/src/haulpave/reporting/summary.py
+++ b/src/haulpave/reporting/summary.py
@@ -7,6 +7,8 @@ reproducibility.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from datetime import datetime, timezone
 from typing import Any
 
@@ -14,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 import haulpave
 
-__all__ = ["DesignSummary", "build_design_summary"]
+__all__ = ["DesignSummary", "build_design_summary", "compute_input_hash"]
 
 
 class DesignSummary(BaseModel):
@@ -27,6 +29,20 @@ class DesignSummary(BaseModel):
     package_version: str = Field(description="haulpave package version string")
     inputs: dict[str, Any] = Field(description="Design inputs as passed by the caller")
     results: dict[str, Any] = Field(description="Computed results keyed by method name")
+    input_hash: str | None = Field(
+        default=None,
+        description="SHA-256 hash of serialized inputs for audit trail",
+    )
+
+
+def compute_input_hash(inputs: dict[str, Any]) -> str:
+    """Compute SHA-256 hash of serialized inputs for audit trail.
+
+    Serialisation is deterministic (``sort_keys=True``, ``default=str``)
+    so that identical inputs always produce the same hash.
+    """
+    serialized = json.dumps(inputs, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
 
 
 def build_design_summary(
@@ -59,4 +75,5 @@ def build_design_summary(
         package_version=haulpave.__version__,
         inputs=inputs,
         results=results if results is not None else {},
+        input_hash=compute_input_hash(inputs),
     )

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -50,6 +50,11 @@ class TestBuildDesignSummary:
         b = build_design_summary(inputs={"coverages": 5000, "cbr": 10})
         assert a.input_hash == b.input_hash
 
+    def test_immutable(self) -> None:
+        result = build_design_summary(inputs={"cbr": 10})
+        with pytest.raises((AttributeError, TypeError, ValidationError)):
+            result.title = "Changed"  # type: ignore[misc]
+
 
 class TestComputeInputHash:
     def test_returns_hex_string(self) -> None:

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from haulpave.reporting.summary import DesignSummary, build_design_summary
+from haulpave.reporting.summary import DesignSummary, build_design_summary, compute_input_hash
 
 
 class TestBuildDesignSummary:
@@ -29,7 +29,40 @@ class TestBuildDesignSummary:
         result = build_design_summary(inputs={"cbr": 5})
         assert result.results == {}
 
-    def test_immutable(self) -> None:
+    def test_input_hash_present(self) -> None:
         result = build_design_summary(inputs={"cbr": 10})
-        with pytest.raises((AttributeError, TypeError, ValidationError)):
-            result.title = "Changed"  # type: ignore[misc]
+        assert result.input_hash is not None
+        assert len(result.input_hash) == 64
+        assert all(c in "0123456789abcdef" for c in result.input_hash)
+
+    def test_input_hash_deterministic(self) -> None:
+        a = build_design_summary(inputs={"cbr": 10, "coverages": 5000})
+        b = build_design_summary(inputs={"cbr": 10, "coverages": 5000})
+        assert a.input_hash == b.input_hash
+
+    def test_input_hash_differs_for_different_inputs(self) -> None:
+        a = build_design_summary(inputs={"cbr": 10})
+        b = build_design_summary(inputs={"cbr": 15})
+        assert a.input_hash != b.input_hash
+
+    def test_input_hash_dict_order_agnostic(self) -> None:
+        a = build_design_summary(inputs={"cbr": 10, "coverages": 5000})
+        b = build_design_summary(inputs={"coverages": 5000, "cbr": 10})
+        assert a.input_hash == b.input_hash
+
+
+class TestComputeInputHash:
+    def test_returns_hex_string(self) -> None:
+        h = compute_input_hash({"cbr": 10})
+        assert isinstance(h, str)
+        assert len(h) == 64
+
+    def test_same_inputs_same_hash(self) -> None:
+        assert compute_input_hash({"a": 1, "b": 2}) == compute_input_hash({"a": 1, "b": 2})
+
+    def test_different_inputs_different_hash(self) -> None:
+        assert compute_input_hash({"a": 1}) != compute_input_hash({"a": 2})
+
+    def test_nested_dicts(self) -> None:
+        h = compute_input_hash({"fleet": [{"name": "Test", "trips": 10}]})
+        assert len(h) == 64


### PR DESCRIPTION
Closes #79

## Summary
Added `input_hash` (SHA-256 of serialized inputs) to `DesignSummary` model and `compute_input_hash()` helper. Deterministic via `sort_keys=True`.

Coverage: 100% on reporting/summary.py (11 tests).

## Test plan
- [x] `build_design_summary()` produces non-null hex hash
- [x] Same inputs → same hash (deterministic)
- [x] Different inputs → different hash
- [x] Dict key order agnostic (sort_keys=True)