### PR TITLE
[DAS-80] RoadScenario.thickness_mm dead field — accepted but unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ print(f"Required thickness: {thickness_mm:.0f} mm")
 
 # 4. Compare surface scenarios
 scenarios = [
-    RoadScenario(name="Asphalt", surface="asphalt", thickness_mm=thickness_mm,
+    RoadScenario(name="Asphalt", surface="asphalt",
                  haul_distance_km=10, trips_per_day=30),
-    RoadScenario(name="Gravel",  surface="gravel",  thickness_mm=400,
+    RoadScenario(name="Gravel",  surface="gravel",
                  haul_distance_km=10, trips_per_day=30),
 ]
 comparison = compare_scenarios(scenarios)

--- a/docs/api/economics.md
+++ b/docs/api/economics.md
@@ -93,7 +93,6 @@ rolling-resistance linear cost model.
 class RoadScenario(BaseModel):
     name: str
     surface: Literal["asphalt", "gravel", "concrete"]
-    thickness_mm: float  # Pavement design thickness [mm]
     haul_distance_km: float  # One-way haul distance [km]
     trips_per_day: float  # One-way vehicle trips per day
 ```

--- a/examples/02_trh14_vs_usace_comparison.py
+++ b/examples/02_trh14_vs_usace_comparison.py
@@ -36,23 +36,18 @@ def main() -> None:
         working_days_per_year=350,
     )
 
+    print(f"\nFleet: {traffic.fleet[0].vehicle.name} @ {traffic.fleet[0].trips_per_day} trips/day")
     print(
-        f"\nFleet: {traffic.fleet[0].vehicle.name}"
-        f" @ {traffic.fleet[0].trips_per_day} trips/day"
-    )
-    print(
-        f"Design life: {traffic.design_life_years} years,"
-        f" {traffic.working_days_per_year} days/yr"
+        f"Design life: {traffic.design_life_years} years, {traffic.working_days_per_year} days/yr"
     )
     print()
 
     cbr_values = [3.0, 5.0, 10.0]
 
     print(
-        f"{'CBR':>5}  {'USACE (mm)':>12}  {'TRH 14 (mm)':>12}"
-        f"  {'Delta (mm)':>12}  {'G-Class':>8}"
+        f"{'CBR':>5}  {'USACE (mm)':>12}  {'TRH 14 (mm)':>12}  {'Delta (mm)':>12}  {'G-Class':>8}"
     )
-    print(f"{'-'*5}  {'-'*12}  {'-'*12}  {'-'*12}  {'-'*8}")
+    print(f"{'-' * 5}  {'-' * 12}  {'-' * 12}  {'-' * 12}  {'-' * 8}")
 
     for cbr in cbr_values:
         try:

--- a/examples/02_trh14_vs_usace_comparison.py
+++ b/examples/02_trh14_vs_usace_comparison.py
@@ -36,13 +36,22 @@ def main() -> None:
         working_days_per_year=350,
     )
 
-    print(f"\nFleet: {traffic.fleet[0].vehicle.name} @ {traffic.fleet[0].trips_per_day} trips/day")
-    print(f"Design life: {traffic.design_life_years} years, {traffic.working_days_per_year} days/yr")
+    print(
+        f"\nFleet: {traffic.fleet[0].vehicle.name}"
+        f" @ {traffic.fleet[0].trips_per_day} trips/day"
+    )
+    print(
+        f"Design life: {traffic.design_life_years} years,"
+        f" {traffic.working_days_per_year} days/yr"
+    )
     print()
 
     cbr_values = [3.0, 5.0, 10.0]
 
-    print(f"{'CBR':>5}  {'USACE (mm)':>12}  {'TRH 14 (mm)':>12}  {'Delta (mm)':>12}  {'G-Class':>8}")
+    print(
+        f"{'CBR':>5}  {'USACE (mm)':>12}  {'TRH 14 (mm)':>12}"
+        f"  {'Delta (mm)':>12}  {'G-Class':>8}"
+    )
     print(f"{'-'*5}  {'-'*12}  {'-'*12}  {'-'*12}  {'-'*8}")
 
     for cbr in cbr_values:

--- a/examples/03_economics_scenario.py
+++ b/examples/03_economics_scenario.py
@@ -79,11 +79,18 @@ def main() -> None:
         working_days_per_year=250,
     )
 
-    print(f"{'Surface':>10}  {'Fuel ($/yr)':>14}  {'Tyres ($/yr)':>14}  {'Maint ($/yr)':>14}  {'Total ($/yr)':>14}")
+    print(
+        f"{'Surface':>10}  {'Fuel ($/yr)':>14}  {'Tyres ($/yr)':>14}"
+        f"  {'Maint ($/yr)':>14}  {'Total ($/yr)':>14}"
+    )
     print(f"{'-'*10}  {'-'*14}  {'-'*14}  {'-'*14}  {'-'*14}")
 
     for sc in comp.scenarios:
-        total = sc.fuel_cost_usd_per_year + sc.tire_cost_usd_per_year + sc.maintenance_cost_usd_per_year
+        total = (
+            sc.fuel_cost_usd_per_year
+            + sc.tire_cost_usd_per_year
+            + sc.maintenance_cost_usd_per_year
+        )
         print(
             f"{sc.name:>10}  {sc.fuel_cost_usd_per_year:>14,.0f}  "
             f"{sc.tire_cost_usd_per_year:>14,.0f}  "

--- a/examples/03_economics_scenario.py
+++ b/examples/03_economics_scenario.py
@@ -56,21 +56,18 @@ def main() -> None:
         RoadScenario(
             name="Asphalt",
             surface="asphalt",
-            thickness_mm=450.0,
             haul_distance_km=5.0,
             trips_per_day=40.0,
         ),
         RoadScenario(
             name="Gravel",
             surface="gravel",
-            thickness_mm=500.0,
             haul_distance_km=5.0,
             trips_per_day=40.0,
         ),
         RoadScenario(
             name="Concrete",
             surface="concrete",
-            thickness_mm=400.0,
             haul_distance_km=5.0,
             trips_per_day=40.0,
         ),

--- a/examples/03_economics_scenario.py
+++ b/examples/03_economics_scenario.py
@@ -83,13 +83,11 @@ def main() -> None:
         f"{'Surface':>10}  {'Fuel ($/yr)':>14}  {'Tyres ($/yr)':>14}"
         f"  {'Maint ($/yr)':>14}  {'Total ($/yr)':>14}"
     )
-    print(f"{'-'*10}  {'-'*14}  {'-'*14}  {'-'*14}  {'-'*14}")
+    print(f"{'-' * 10}  {'-' * 14}  {'-' * 14}  {'-' * 14}  {'-' * 14}")
 
     for sc in comp.scenarios:
         total = (
-            sc.fuel_cost_usd_per_year
-            + sc.tire_cost_usd_per_year
-            + sc.maintenance_cost_usd_per_year
+            sc.fuel_cost_usd_per_year + sc.tire_cost_usd_per_year + sc.maintenance_cost_usd_per_year
         )
         print(
             f"{sc.name:>10}  {sc.fuel_cost_usd_per_year:>14,.0f}  "

--- a/src/haulpave/economics/compare.py
+++ b/src/haulpave/economics/compare.py
@@ -51,7 +51,6 @@ class RoadScenario(BaseModel):
 
     name: str = Field(min_length=1)
     surface: Literal["asphalt", "gravel", "concrete"]
-    thickness_mm: float = Field(ge=0, description="Pavement design thickness [mm]")
     haul_distance_km: float = Field(gt=0, description="One-way haul distance [km]")
     trips_per_day: float = Field(gt=0, description="One-way vehicle trips per day")
 

--- a/tests/benchmarks/bench_06_economics_compare.py
+++ b/tests/benchmarks/bench_06_economics_compare.py
@@ -84,21 +84,18 @@ def three_surface_scenarios() -> list[RoadScenario]:
         RoadScenario(
             name="Asphalt",
             surface="asphalt",
-            thickness_mm=100,
             haul_distance_km=HAUL_KM,
             trips_per_day=TRIPS_PER_DAY,
         ),
         RoadScenario(
             name="Gravel",
             surface="gravel",
-            thickness_mm=600,
             haul_distance_km=HAUL_KM,
             trips_per_day=TRIPS_PER_DAY,
         ),
         RoadScenario(
             name="Concrete",
             surface="concrete",
-            thickness_mm=200,
             haul_distance_km=HAUL_KM,
             trips_per_day=TRIPS_PER_DAY,
         ),
@@ -230,7 +227,6 @@ class TestOrderingInvariants:
             RoadScenario(
                 name="A",
                 surface="asphalt",
-                thickness_mm=100,
                 haul_distance_km=5.0,
                 trips_per_day=20,
             )
@@ -239,7 +235,6 @@ class TestOrderingInvariants:
             RoadScenario(
                 name="A",
                 surface="asphalt",
-                thickness_mm=100,
                 haul_distance_km=10.0,
                 trips_per_day=20,
             )

--- a/tests/test_economics/test_compare.py
+++ b/tests/test_economics/test_compare.py
@@ -60,12 +60,8 @@ class TestCompareScenarios:
 
     def test_concrete_cheapest(self) -> None:
         scenarios = [
-            RoadScenario(
-                name="A", surface="asphalt", haul_distance_km=10, trips_per_day=10
-            ),
-            RoadScenario(
-                name="G", surface="gravel", haul_distance_km=10, trips_per_day=10
-            ),
+            RoadScenario(name="A", surface="asphalt", haul_distance_km=10, trips_per_day=10),
+            RoadScenario(name="G", surface="gravel", haul_distance_km=10, trips_per_day=10),
             RoadScenario(
                 name="C",
                 surface="concrete",

--- a/tests/test_economics/test_compare.py
+++ b/tests/test_economics/test_compare.py
@@ -13,14 +13,12 @@ def two_scenarios() -> list[RoadScenario]:
         RoadScenario(
             name="Asphalt",
             surface="asphalt",
-            thickness_mm=100,
             haul_distance_km=5.0,
             trips_per_day=20,
         ),
         RoadScenario(
             name="Gravel",
             surface="gravel",
-            thickness_mm=600,
             haul_distance_km=5.0,
             trips_per_day=20,
         ),
@@ -63,15 +61,14 @@ class TestCompareScenarios:
     def test_concrete_cheapest(self) -> None:
         scenarios = [
             RoadScenario(
-                name="A", surface="asphalt", thickness_mm=100, haul_distance_km=10, trips_per_day=10
+                name="A", surface="asphalt", haul_distance_km=10, trips_per_day=10
             ),
             RoadScenario(
-                name="G", surface="gravel", thickness_mm=600, haul_distance_km=10, trips_per_day=10
+                name="G", surface="gravel", haul_distance_km=10, trips_per_day=10
             ),
             RoadScenario(
                 name="C",
                 surface="concrete",
-                thickness_mm=200,
                 haul_distance_km=10,
                 trips_per_day=10,
             ),

--- a/tests/test_economics/test_export.py
+++ b/tests/test_economics/test_export.py
@@ -22,21 +22,18 @@ def comparison_result() -> ComparisonResult:
         RoadScenario(
             name="Asphalt",
             surface="asphalt",
-            thickness_mm=100,
             haul_distance_km=5.0,
             trips_per_day=20,
         ),
         RoadScenario(
             name="Gravel",
             surface="gravel",
-            thickness_mm=600,
             haul_distance_km=5.0,
             trips_per_day=20,
         ),
         RoadScenario(
             name="Concrete",
             surface="concrete",
-            thickness_mm=200,
             haul_distance_km=5.0,
             trips_per_day=20,
         ),


### PR DESCRIPTION
Closes #80

## Summary
Removed unused `thickness_mm` field from `RoadScenario` model. Updated all references: tests, benchmarks, examples.

All 28 affected tests pass + example runs successfully.

## Test plan
- [x] `test_compare.py` — all 7 tests pass without thickness_mm
- [x] `test_export.py` — all 5 tests pass
- [x] `bench_06` — all 16 benchmark tests pass
- [x] `examples/03_economics_scenario.py` — runs correctly